### PR TITLE
Don't include bad time intervals that are null

### DIFF
--- a/xija/model.py
+++ b/xija/model.py
@@ -114,7 +114,8 @@ class XijaModel(object):
             for t0, t1 in self.bad_times:
                 t0, t1 = DateTime([t0, t1]).secs
                 i0, i1 = np.searchsorted(self.times, [t0, t1])
-                self.bad_times_indices.append((i0, i1))
+                if i1 > i0:
+                    self.bad_times_indices.append((i0, i1))
 
         self.pars = []
         if model_spec:


### PR DESCRIPTION
Previously bad time intervals that are outside of the model time range would result in a null interval, with indices `[0, 0]`.  This was fine for fitting but crashed the plotting.
