### PR TITLE
Make gui_fit recenter epoch on fit window by default for linear models

### DIFF
--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -112,6 +112,10 @@ class SolarHeat(PrecomputedHeatPower):
             Ps += dPs * days / self.tau
             for par, P in izip(self.pars, Ps):
                 par.val = P
+                if P > par.max:
+                    par.max = P
+                elif P < par.min:
+                    par.min = P
 
             print('Updated model component {} epoch from {} to {}'
                   .format(self, epoch.date[:8], new_epoch.date[:8]))

--- a/xija/gui_fit.py
+++ b/xija/gui_fit.py
@@ -649,6 +649,10 @@ def get_options():
                       default=False,
                       action='store_true',
                       help="Suppress screen output")
+    parser.add_argument("--keep-epoch",
+                      default=False,
+                      action='store_true',
+                      help="Maintain epoch in SolarHeat models (default=recenter on fit interval)")
 
     return parser.parse_args()
 
@@ -715,6 +719,15 @@ def main():
 
     gui_config['filename'] = os.path.abspath(opt.filename)
     gui_config['set_data_vals'] = set_data_vals
+
+    if not opt.keep_epoch:
+        new_epoch = np.mean(model.times[[0, -1]])
+        for comp in model.comp.values():
+            if isinstance(comp, xija.SolarHeat):
+                try:
+                    comp.epoch = new_epoch
+                except AttributeError as err:
+                    assert 'can only reset the epoch' in str(err)
 
     fit_worker = FitWorker(model, opt.fit_method)
 


### PR DESCRIPTION
This should make the typical model fitting process easier by recentering the model `epoch` for `SolarHeat`-based models that have linear long-term dependence.  This behavior is the default, but it can be disabled by passing the `--keep-epoch` flag when calling `gui_fit.py`.

A typical fitting sequence could then be:

1. Fit the solar heat `P` parameters for the most recent year of data, letting `gui_fit` recenter the epoch.  In this stage leave the `dP` values at the previous best fit values (do not zero the out).  Save and close.
2. Ft the solar heat `dP` parameters for the most recent 2-3 years, using the `--keep-epoch` flag to maintain the epoch at the center of the 1-year fit.  In this way the epoch refers to the center of the data used to determine the solar heat `P` values.

@matthewdahmer @jeanconn