### PR TITLE
Add SolarHeatOffNomRoll and Roll components

### DIFF
--- a/xija/component/base.py
+++ b/xija/component/base.py
@@ -424,3 +424,8 @@ class SimZ(TelemData):
     def get_dvals_tlm(self):
         sim_z_mm = self.model.fetch(self.msid)
         return np.rint(sim_z_mm * -397.7225924607)
+
+
+class Roll(TelemData):
+    def __init__(self, model):
+        TelemData.__init__(self, model, 'roll')

--- a/xija/version.py
+++ b/xija/version.py
@@ -8,7 +8,7 @@ NOTE: this code copied from astropy.version and simplified.  Any license
 restrictions therein are applicable.
 """
 
-version = '0.6'
+version = '0.7'
 
 _versplit = version.replace('dev', '').split('.')
 major = int(_versplit[0])


### PR DESCRIPTION
Add heating of a +Y or -Y face of a spacecraft component due to off-nominal roll.  The
heating is proportional to the projection of the sun on body +Y axis (which is a value
from -1 to 1).  There are two parameters `P_plus_y` and `P_minus_y`.  For sun on
the +Y side the `P_plus_y` parameter is used, and likewise for sun on -Y.  For
example for +Y sun:

    heat = P_plus_y * sun_body_y

The following reference has useful diagrams concerning off-nominal roll and
projections: http://occweb.cfa.harvard.edu/twiki/pub/Aspect/WebHome/ROLLDEV3.pdf.
