### PR TITLE
Allow the timestep to be set from the model specification

### DIFF
--- a/xija/model.py
+++ b/xija/model.py
@@ -46,6 +46,8 @@ if 'debug' in globals():
 
 logger = clogging.config_logger('xija', level=clogging.INFO)
 
+DEFAULT_DT = 328.0
+
 #int calc_model(int n_times, int n_preds, int n_tmals, double dt,
 #               double **mvals, int **tmal_ints, double **tmal_floats)
 
@@ -97,10 +99,11 @@ class XijaModel(object):
         if name is None:
             name = 'xijamodel'
         if dt is None:
-            dt = 328.0
+            dt = DEFAULT_DT
 
-        if dt > 328.0:
-            raise RuntimeError("dt = %g s greater than upper limit of 328 s!" % dt)
+        if dt > DEFAULT_DT:
+            raise RuntimeError("dt = %g s greater than upper "
+                               "limit of %g s!" % (dt, DEFAULT_DT))
 
         self.name = name
         self.comp = OrderedDict()
@@ -220,7 +223,7 @@ class XijaModel(object):
 
     def fetch(self, msid, attr='vals', method='linear'):
         """Get data from the Chandra engineering archive."""
-        tpad = max(self.dt * 5, 328.0*5)
+        tpad = DEFAULT_DT*5.0
         datestart = DateTime(self.tstart - tpad).date
         datestop = DateTime(self.tstop + tpad).date
         logger.info('Fetching msid: %s over %s to %s' %

--- a/xija/model.py
+++ b/xija/model.py
@@ -106,7 +106,7 @@ class XijaModel(object):
         self.comp = OrderedDict()
         self.dt = self._check_timestep(dt)
         self.dt_ksec = self.dt / 1000.
-        self.times = self._eng_match_times(start, stop, dt)
+        self.times = self._eng_match_times(start, stop)
         self.tstart = self.times[0]
         self.tstop = self.times[-1]
         self.ksecs = (self.times - self.tstart) / 1000.
@@ -183,16 +183,15 @@ class XijaModel(object):
                 par.frozen = inherit_pars[par.full_name]['frozen']
                 par.fmt = inherit_pars[par.full_name]['fmt']
 
-    @staticmethod
-    def _eng_match_times(start, stop, dt):
+    def _eng_match_times(self, start, stop):
         """Return an array of times between ``start`` and ``stop`` at ``dt``
         sec intervals.  The times are roughly aligned (within 1 sec) to the
         timestamps in the '5min' (328 sec) Ska eng archive data.
         """
         time0 = 410270764.0
-        i0 = int((DateTime(start).secs - time0) / dt) + 1
-        i1 = int((DateTime(stop).secs - time0) / dt)
-        return time0 + np.arange(i0, i1) * dt
+        i0 = int((DateTime(start).secs - time0) / self.dt) + 1
+        i1 = int((DateTime(stop).secs - time0) / self.dt)
+        return time0 + np.arange(i0, i1) * self.dt
 
     def _get_cmd_states(self):
         if not hasattr(self, '_cmd_states'):

--- a/xija/model.py
+++ b/xija/model.py
@@ -104,7 +104,7 @@ class XijaModel(object):
 
         self.name = name
         self.comp = OrderedDict()
-        self.dt = self._check_timestep(dt)
+        self.dt = self._get_allowed_timestep(dt)
         self.dt_ksec = self.dt / 1000.
         self.times = self._eng_match_times(start, stop)
         self.tstart = self.times[0]
@@ -131,7 +131,7 @@ class XijaModel(object):
             self._set_from_model_spec(model_spec)
         self.cmd_states = cmd_states
 
-    def _check_timestep(self, dt):
+    def _get_allowed_timestep(self, dt):
         """
         This method ensures that only certain timesteps are chosen,
         which are integer multiples of 8.2 and where 328.0/dt is an

--- a/xija/model.py
+++ b/xija/model.py
@@ -220,7 +220,7 @@ class XijaModel(object):
 
     def fetch(self, msid, attr='vals', method='linear'):
         """Get data from the Chandra engineering archive."""
-        tpad = self.dt * 5
+        tpad = max(self.dt * 5, 328.0*5)
         datestart = DateTime(self.tstart - tpad).date
         datestop = DateTime(self.tstop + tpad).date
         logger.info('Fetching msid: %s over %s to %s' %

--- a/xija/model.py
+++ b/xija/model.py
@@ -73,11 +73,11 @@ class XijaModel(object):
     :param name: model name
     :param start: model start time (any DateTime format)
     :param stop: model stop time (any DateTime format)
-    :param dt: delta time step (default=328 sec, do not change)
+    :param dt: delta time step (default=328 sec)
     :param model_spec: model specification (None | filename | dict)
     :param cmd_states: commanded states input (None | structured array)
     """
-    def __init__(self, name=None, start=None, stop=None, dt=328.0,
+    def __init__(self, name=None, start=None, stop=None, dt=None,
                  model_spec=None, cmd_states=None):
 
         # If model_spec supplied as a string then read model spec as a dict
@@ -88,6 +88,7 @@ class XijaModel(object):
             stop = stop or model_spec['datestop']
             start = start or model_spec['datestart']
             name = name or model_spec['name']
+            dt = dt or model_spec['dt']
 
         if stop is None:
             stop = DateTime() - 30
@@ -95,6 +96,8 @@ class XijaModel(object):
             start = DateTime(stop) - 45
         if name is None:
             name = 'xijamodel'
+        if dt is None:
+            dt = 328.0
 
         self.name = name
         self.comp = OrderedDict()

--- a/xija/model.py
+++ b/xija/model.py
@@ -99,6 +99,9 @@ class XijaModel(object):
         if dt is None:
             dt = 328.0
 
+        if dt > 328.0:
+            raise RuntimeError("dt = %g s greater than upper limit of 328 s!" % dt)
+
         self.name = name
         self.comp = OrderedDict()
         self.dt = dt


### PR DESCRIPTION
Most models have a `dt` of 328 seconds as the default. The ACIS DEA Housekeeping telemetry (most importantly the focal plane temperature) has a much higher time resolution than this. 

Currently in xija even if a smaller `dt` is specified in the model specification it is not changed when the model is run. This PR makes some modest changes to allow the timestep to be ingested from the model specification. In most cases, models will set the `dt` to 328 seconds, and the code here ensures that the default does not change. 