### PR TITLE
Support the (soon-to-be) latest version of taco

### DIFF
--- a/xija/__init__.py
+++ b/xija/__init__.py
@@ -3,8 +3,7 @@ from .model import *
 from .component import *
 from .files import files
 
-__version__ = '3.9'
-
+__version__ = '3.10'
 
 def test(*args, **kwargs):
     '''

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -394,7 +394,7 @@ class EarthHeat(PrecomputedHeatPower):
     @property
     def dvals(self):
         try:
-            import taco
+            import acis_taco as taco
         except ImportError:
             import Chandra.taco as taco
         if not hasattr(self, '_dvals') and not self.get_cached():

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -393,7 +393,10 @@ class EarthHeat(PrecomputedHeatPower):
 
     @property
     def dvals(self):
-        import Chandra.taco
+        try:
+            import taco
+        except ImportError:
+            import Chandra.taco as taco
         if not hasattr(self, '_dvals') and not self.get_cached():
             # Collect individual MSIDs for use in calc_earth_vis()
             ephem_xyzs = [getattr(self, 'orbitephem0_{}'.format(x))
@@ -411,7 +414,7 @@ class EarthHeat(PrecomputedHeatPower):
                     q_att = np.array([0.0, 0.0, 0.0, 1.0])
                 else:
                     q_att = q_att / q_norm
-                _, illums, _ = Chandra.taco.calc_earth_vis(ephem, q_att)
+                _, illums, _ = taco.calc_earth_vis(ephem, q_att)
                 self._dvals[i] = illums.sum()
 
             self.put_cache()

--- a/xija/gui_fit.py
+++ b/xija/gui_fit.py
@@ -28,7 +28,10 @@ import sherpa.ui as ui
 from Chandra.Time import DateTime
 import pyyaks.context as pyc
 
-import Chandra.taco
+try:
+    import taco
+except ImportError:
+    import Chandra.taco as taco
 import xija
 import xija.clogging as clogging   # get rid of this or something
 
@@ -662,7 +665,7 @@ def get_options():
 def main():
     # Enable fully-randomized evaluation of ACIS-FP model which is desirable
     # for fitting.
-    Chandra.taco.taco.set_random_salt(None)
+    taco.taco.set_random_salt(None)
 
     opt = get_options()
 

--- a/xija/gui_fit.py
+++ b/xija/gui_fit.py
@@ -29,7 +29,7 @@ from Chandra.Time import DateTime
 import pyyaks.context as pyc
 
 try:
-    import taco
+    import acis_taco as taco
 except ImportError:
     import Chandra.taco as taco
 import xija


### PR DESCRIPTION
In the next version of `taco`, it will be a top-level package. This PR makes sure that regardless of whether `taco` is installed or `Chandra.taco` is installed, it can be used with `xija`. 