### PR TITLE
Allow for two "hrc_bias" parameters

### DIFF
--- a/xija/__init__.py
+++ b/xija/__init__.py
@@ -3,7 +3,7 @@ from .model import *
 from .component import *
 from .files import files
 
-__version__ = '3.8'
+__version__ = '3.9'
 
 
 def test(*args, **kwargs):

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -365,8 +365,7 @@ class SolarHeatHrcOpts(SolarHeat):
                              (self.simz_comp.dvals > -86147)
         self._dvals[self.hrci_mask] += self.hrci_bias
         if not hasattr(self, 'hrcs_mask'):
-            self.hrcs_mask = (self.simz_comp.dvals <= -86147) & \
-                             (self.simz_comp.dvals >= -104362)
+            self.hrcs_mask = self.simz_comp.dvals <= -86147
         self._dvals[self.hrcs_mask] += self.hrcs_bias
 
 


### PR DESCRIPTION
The ACIS Ops team has discovered that the single `hrc_bias` parameter which adjusts the expected pitch-dependent solar heating if HRC is in the focal plane is not sufficient to reproduce the temperature behavior for both cases: HRC-I is in the focal plane or HRC-S. Since we spend far more time with HRC-S in the focal plane, this parameter is calibrated well for that case but not for HRC-I.

~~This PR allows a thermal model specification to specify that two bias parameters should be set by setting the `hrc_bias` parameter in  the `SolarHeatHrc` class constructor to a 2-element iterable such as a list, which can be done in the JSON file. This creates two bias parameters, `hrci_bias` and `hrcs_bias`, which then will correspond to the different SIM positions.~~

~~My original thought was to simply change the signature of `SolarHeatHrc` to provide for two parameters, but this breaks backward-compatibility, hence the solution presented here, which while a little awkward supports both types of behavior.~~ 

This PR adds a new class, `SolarHeatHrcOpts`, which has two parameters related to the HRC bias, `hrci_bias` and `hrcs_bias`, which apply when HRC-I or HRC-S is in the focal plane.