### PR TITLE
Expand the upper end of the supported pitch range from 170 to 180 degrees

### DIFF
--- a/xija/__init__.py
+++ b/xija/__init__.py
@@ -3,7 +3,7 @@ from .model import *
 from .component import *
 from .files import files
 
-__version__ = '4.13'
+__version__ = '4.13.1'
 
 def test(*args, **kwargs):
     '''

--- a/xija/__init__.py
+++ b/xija/__init__.py
@@ -3,7 +3,7 @@ from .model import *
 from .component import *
 from .files import files
 
-__version__ = '4.13.1'
+__version__ = '4.14'
 
 def test(*args, **kwargs):
     '''

--- a/xija/component/base.py
+++ b/xija/component/base.py
@@ -382,9 +382,9 @@ class Pitch(TelemData):
         # the spacecraft is at normal sun.  So set these values to 90.
         bad = (vals >= 180.0) | (vals <= 45.0)
         vals[bad] = 90.0
-        # Thermal models typically calibrated between 45 to 170 degrees
-        # so clip values to that range.
-        vals.clip(45.001, 169.999, out=vals)
+        # Spacecraft must operate between 45 and 180 degrees pitch, so clip
+        # values to that range.
+        vals.clip(45.001, 179.999, out=vals)
         return vals
 
     def __str__(self):

--- a/xija/tests/test_models.py
+++ b/xija/tests/test_models.py
@@ -68,6 +68,28 @@ def test_pitch_clip():
     mdl.make()
     mdl.calc()
 
+
+def test_pitch_range_clip():
+    """
+    Pitch in this time range goes from approximately 48.5 to 175.0 degrees.
+    pftank2t.json is used as a placeholder to load a new thermal model, and
+    should be able to be replaced with any other model. Make sure the pitch
+    range stored in the model object does not get clipped to a narrower range.
+    Make sure the pitch range stored does not include values outside of the 45
+    to 180 degree range.
+    """
+    mdl = ThermalModel('tank', start='2019:120', stop='2019:122',
+                       model_spec=abs_path('pftank2t.json'))
+
+    mdl.comp['pf0tank2t'].set_data(20.0)
+    mdl.make()
+    mdl.calc()
+
+    pitch = mdl.get_comp('pitch')
+    assert np.any(pitch.mvals > 170)
+    assert np.all((pitch.mvals > 45) & (pitch.mvals < 180))
+
+
 def test_dpa_remove_pow():
     mdl = ThermalModel('dpa', start='2012:001', stop='2012:007',
                        model_spec=abs_path('dpa_remove_pow.json'))


### PR DESCRIPTION
This expands the upper end of the supported pitch range from 170 degrees (169.999 degrees) to 180 degrees (179.999 degrees) to reflect the expanded allowable pitch range being explored.