### PR TITLE
Add option for multiplicative yearly dependence of solar heating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ doc/_templates
 *.pyc
 examples/
 .nfs*
+xija.egg-info

--- a/xija/__init__.py
+++ b/xija/__init__.py
@@ -3,7 +3,7 @@ from .model import *
 from .component import *
 from .files import files
 
-__version__ = '4.14'
+__version__ = '4.15'
 
 def test(*args, **kwargs):
     '''

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -70,7 +70,7 @@ class SolarHeatBase(PrecomputedHeatPower):
     @property
     def h_phase(self):
         if self._h_phase is None:
-            e = 0.0167
+            e = 0.0167 # earth eccentricity
             self._h_phase = (1.0+2.0*e*np.cos(self.t_phase))
         return self._h_phase
 

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -222,8 +222,8 @@ class SolarHeat(PrecomputedHeatPower):
         P_vals = Ps_interp(self.pitches)
         dP_vals = dPs_interp(self.pitches)
         self.P_vals = P_vals
-        self._dvals = (P_vals + dP_vals * self.var_func(self.t_days, self.tau)
-                       + self.ampl * np.cos(self.t_phase)).reshape(-1)
+        self._dvals = ((P_vals + dP_vals * self.var_func(self.t_days, self.tau)) *
+                       (1.0 + self.ampl * np.cos(self.t_phase))).reshape(-1)
         # Set power to 0.0 during eclipse (where eclipse_comp.dvals == True)
         if self.eclipse_comp is not None:
             self._dvals[self.eclipse_comp.dvals] = 0.0

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -356,7 +356,7 @@ class SolarHeatAcisCameraBody(SolarHeat):
         self._dvals[self.dh_heater_comp.dvals] += self.dh_heater_bias
 
 
-class SolarHeatHrc(NewSolarHeat):
+class SolarHeatHrc(SolarHeat):
     """Solar heating (pitch and SIM-Z dependent)
 
     :param model: parent model
@@ -392,7 +392,7 @@ class SolarHeatHrc(NewSolarHeat):
         self._dvals[self.hrc_mask] += self.hrc_bias
 
 
-class SolarHeatHrcOpts(NewSolarHeat):
+class SolarHeatHrcOpts(SolarHeat):
     """Solar heating (pitch and SIM-Z dependent, two parameters for
     HRC-I and HRC-S)
 
@@ -434,6 +434,8 @@ class SolarHeatHrcOpts(NewSolarHeat):
             self.hrcs_mask = self.simz_comp.dvals <= -86147
         self._dvals[self.hrcs_mask] += self.hrcs_bias
 
+class NewSolarHeatHrcOpts(SolarHeatHrcOpts, NewSolarHeat):
+    pass
 
 # For back compatibility prior to Xija 0.2
 DpaSolarHeat = SolarHeatHrc

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -79,12 +79,20 @@ class SolarHeatOffNomRoll(PrecomputedHeatPower):
 
     @property
     def dvals(self):
+        if not hasattr(self, 't_phase'):
+            time2000 = DateTime('2000:001:00:00:00').secs
+            time2010 = DateTime('2010:001:00:00:00').secs
+            secs_per_year = (time2010 - time2000) / 10.0
+            t_year = (self.pitch_comp.times - time2000) / secs_per_year
+            self.t_phase = t_year * 2 * np.pi
+
         if not hasattr(self, 'sun_body_y'):
             # Compute the projection of the sun vector on the body +Y axis.
             # Pitch and off-nominal roll (theta_S and d_phi in OFLS terminology)
+            e = 0.0167
             theta_S = np.radians(self.pitch_comp.dvals)
             d_phi = np.radians(self.roll_comp.dvals)
-            self.sun_body_y = np.sin(theta_S) * np.sin(d_phi)
+            self.sun_body_y = np.sin(theta_S) * np.sin(d_phi) * (1.0+2.0*e*np.cos(self.t_phase))
             self.plus_y = self.sun_body_y > 0
 
         self._dvals = np.where(self.plus_y, self.P_plus_y, self.P_minus_y) * self.sun_body_y


### PR DESCRIPTION
The current code for computing the yearly variation in solar heating due to the change in the Earth's distance to the Sun has a bug. The mathematical background which led me to discover this is found here:

[solarheat_orbit.pdf](https://github.com/sot/xija/files/3302107/solarheat_orbit.pdf)

This PR does the following things:

- Fixes the variation in solar heating
- ~~Adds this effect to the `SolarHeatOffNomRoll` and `EarthHeat` classes by creating a `SolarHeatBase` superclass which `SolarHeat` and its subclasses also use.~~
- Adds a new `NewSolarHeat` class so we can implement this fix in models one by one without having to change them all at once. Eventually the `NewSolarHeat` class should replace the `SolarHeat` class. 

Preliminary tests using the ACIS DPA and DEA models show improvements in fitting hot and cold seasons simultaneously. ~~I still want to spend some more time fitting this model and the ACIS FP model to verify that this fix helps.~~ Implementing this into the ACIS FP model requires more work. 