### PR TITLE
Add optional bias parameters for ACIS SolarHeat subclasses for ACIS sim positions

### DIFF
--- a/xija/__init__.py
+++ b/xija/__init__.py
@@ -3,7 +3,7 @@ from .model import *
 from .component import *
 from .files import files
 
-__version__ = '4.15'
+__version__ = '4.16'
 
 def test(*args, **kwargs):
     '''

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -432,7 +432,7 @@ class SolarHeatHrcMult(SolarHeatHrcOpts, SolarHeatMulplicative):
     def __init__(self, model, node, simz_comp, pitch_comp, eclipse_comp=None,
                  P_pitches=None, Ps=None, dPs=None, var_func='exp',
                  tau=1732.0, ampl=0.0334, bias=0.0, epoch='2010:001',
-                 hrci_bias=0.0, hrcs_bias=0.0, acisi_bias=0.0, aciss_bias=0.0):
+                 hrci_bias=0.0, hrcs_bias=0.0, acisi_bias=None, aciss_bias=None):
         super(SolarHeatHrcMult, self).__init__(
             model, node, simz_comp, pitch_comp, eclipse_comp=eclipse_comp,
             P_pitches=P_pitches, Ps=Ps, dPs=dPs, var_func=var_func, tau=tau,

--- a/xija/gui_fit.py
+++ b/xija/gui_fit.py
@@ -38,8 +38,7 @@ except ImportError:
 import xija
 import sherpa.ui as ui
 
-logging.basicConfig(level=logging.DEBUG)
-logging.debug('Importing gui_fit from {}'.format(__file__))
+logging.basicConfig(level=logging.WARNING)
 
 fit_logger = pyyaks.logger.get_logger(name='fit', level=logging.INFO,
                                       format='[%(levelname)s] (%(processName)-10s) %(message)s')
@@ -131,7 +130,7 @@ class FitWorker(object):
         """
         self.fit_process = multiprocessing.Process(target=self.fit)
         self.fit_process.start()
-        logging.debug('Fit started')
+        logging.info('Fit started')
 
     def terminate(self, widget=None):
         """Terminate a Sherpa fit process in a controlled way by sending a
@@ -141,7 +140,7 @@ class FitWorker(object):
             # Only do this if we had started a fit to begin with
             self.parent_pipe.send('terminate')
             self.fit_process.join()
-            logging.debug('Fit terminated')
+            logging.info('Fit terminated')
 
     def fit(self):
         dummy_data = np.zeros(1)
@@ -168,10 +167,10 @@ class FitWorker(object):
             try:
                 ui.fit(1)
                 calc_stat.message['status'] = 'finished'
-                logging.debug('Fit finished normally')
+                logging.info('Fit finished normally')
             except FitTerminated as err:
                 calc_stat.message['status'] = 'terminated'
-                logging.debug('Got FitTerminated exception {}'.format(err))
+                logging.warning('Got FitTerminated exception {}'.format(err))
 
         self.child_pipe.send(calc_stat.message)
 

--- a/xija/gui_fit.py
+++ b/xija/gui_fit.py
@@ -38,7 +38,7 @@ except ImportError:
 import xija
 import sherpa.ui as ui
 
-logging.basicConfig(level=logging.WARNING)
+logging.basicConfig(level=logging.INFO)
 
 fit_logger = pyyaks.logger.get_logger(name='fit', level=logging.INFO,
                                       format='[%(levelname)s] (%(processName)-10s) %(message)s')


### PR DESCRIPTION
This PR adds bias parameters for ACIS sim positions to the ACIS-specific `SolarHeat` subclasses, which helps with the ACIS focal plane model. It is designed in such a way so that these parameters must be explicitly set in the JSON model spec file in order to be used, thus ensuring backwards-compatibility.

I also changed the logging level in `gui_fit` to avoid voluminous debug-level messages from Matplotlib on startup. 