### PR TITLE
[bugfix] Always start model evolution on even-numbered engineering telemetry indices

### DIFF
--- a/xija/__init__.py
+++ b/xija/__init__.py
@@ -3,7 +3,7 @@ from .model import *
 from .component import *
 from .files import files
 
-__version__ = '4.15'
+__version__ = '4.16'
 
 def test(*args, **kwargs):
     '''

--- a/xija/core.c
+++ b/xija/core.c
@@ -82,6 +82,13 @@ int calc_model(int n_times, int n_preds, int n_tmals, double dt,
 
         for (i = 0; i < n_preds; i++) {
             k2 = dt * deriv[i];
+            /* Note that the use of y[i] here is not 
+               strictly correct for RK2, as it was 
+               updated above in line 27 and thus 
+               represents the value at mvals[i][j0+1]
+               already--changing it now will break
+               all models, however. 
+            */
             mvals[i][j0 + 1] = y[i] + k2 / 2.0;
             mvals[i][j0 + 2] = y[i] + k2;
         }

--- a/xija/core.c
+++ b/xija/core.c
@@ -87,7 +87,8 @@ int calc_model(int n_times, int n_preds, int n_tmals, double dt,
                updated above in line 27 and thus 
                represents the value at mvals[i][j0+1]
                already--changing it now will break
-               all models, however. 
+               all models, however. See discussion at
+               https://github.com/sot/xija/issues/72.
             */
             mvals[i][j0 + 1] = y[i] + k2 / 2.0;
             mvals[i][j0 + 2] = y[i] + k2;

--- a/xija/model.py
+++ b/xija/model.py
@@ -168,6 +168,12 @@ class XijaModel(object):
         """
         time0 = 410270764.0
         i0 = int((DateTime(start).secs - time0) / dt) + 1
+        # Make sure i0 is always even to prevent an off-by-one
+        # issue that may result in model evolution being different
+        # by ~0.1s of degrees C if one begins the evolution at 
+        # different times
+        if i0 % 2 != 0:
+            i0 -= 1
         i1 = int((DateTime(stop).secs - time0) / dt)
         return time0 + np.arange(i0, i1) * dt
 

--- a/xija/model.py
+++ b/xija/model.py
@@ -170,7 +170,7 @@ class XijaModel(object):
         i0 = int((DateTime(start).secs - time0) / dt) + 1
         # Make sure i0 is always even to prevent an off-by-one
         # issue that may result in model evolution being different
-        # by ~0.1s of degrees C if one begins the evolution at 
+        # by ~0.1s of degrees C if one begins the evolution at
         # different times
         if i0 % 2 != 0:
             i0 -= 1


### PR DESCRIPTION
Semi-frequently, at load review comparisons between SOT and FOT thermal models
can be discrepant and cause SOT to report a limit violation when FOT does not
see one. 

One (but not the only) source of this discrepancy is the previously noted
behavior that if one executes the same thermal model beginning at two different
simulated times, the predictions can be off by ~tenths of degrees C, especially
at temperature extrema, and such discrepancies can persist to late evolution
times. An example is shown here--the same model run twice, from the two start
times of `2019:100:21:15:25.2` and `2019:100:20:05:15.2` (approximately 1h10m apart):

![two_models](https://user-images.githubusercontent.com/1914976/71832821-b7243180-3079-11ea-8627-c9f6b55b05a6.png)

while the evolution is very much the same, taking the difference between the two
runs for which the same times are available shows the discrepancies:

![two_models_bad_diff](https://user-images.githubusercontent.com/1914976/71832853-c4d9b700-3079-11ea-9576-a6482f99a227.png)

However, changing the second model's start time by 5 minutes eliminates the
long-term discrepancies, leaving only an error from the initial condition:

![two_models_good_diff](https://user-images.githubusercontent.com/1914976/71832844-c0150300-3079-11ea-9678-902dbb7ab370.png)

Two effects contribute to this behavior. The first is the way we do the
evolution of the ODE in xija: we perform a midpoint method / RK2 integration,
using the `j` and `j+2` time steps as the beginning and end points of an RK2
iteration, and using the `j+1` step as the "midpoint." This results in an
odd-even difference between steps in how their evolution is computed. These
indices matter because we do not begin xija model evolution at arbitrary times
but instead at times which correspond to engineering telemetry. 

The second effect is that in the thermal model evolution there are many effects
contributing to the derivative dT/dt at different times, and the resulting ODE
can become stiff. This occassionally results in oscillatory behavior of the
derivative dT/dt, as shown here in a zoomed-in region of the above model:

![oscillations](https://user-images.githubusercontent.com/1914976/71832898-d7ec8700-3079-11ea-9078-1d8d6da3febd.png)

However, if the model evolution is begun at a slightly different time from
another, and the two models begin at indices which are odd and even, the
oscillatory behavior will not line up but instead be at off-by-one steps:

![oscillations2](https://user-images.githubusercontent.com/1914976/71832907-dcb13b00-3079-11ea-8c20-9f8f0f12b96c.png)

The solution this PR proposes is to always begin model evolution at an even
index in the space of engineering telemetry timesteps. 

This PR also adds a comment to the RK2 integrator, noting an issue which I
discovered where the algorithm implemented there is not strictly RK2. See Issue #72 for a
discussion. I have elected not to fix this here because the
empirically-determined model performance is tuned to the form of the evolution
used in xija and fixing it would this require recalibrating all xija models. 