### PR TITLE
enable triggering conda build using repository dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   release:
     types:
     - created
+  repository_dispatch:
+    types:
+    - conda-build
 
 jobs:
   build-linux:


### PR DESCRIPTION
This is a tiny change to the github actions I just introduced in the last PR. It allows one to trigger the conda build using the REST API. It just might be useful.