### PR TITLE
[bugfix] Wrong line is updated in gui_fit

### DIFF
--- a/xija/component/base.py
+++ b/xija/component/base.py
@@ -266,7 +266,7 @@ class Node(TelemData):
             ax.set_title('{}: model (red) and data (blue)'.format(self.name))
             ax.set_ylabel('Temperature (%s)' % self.units)
         else:
-            lines[1].set_ydata(self.mvals)
+            lines[0].set_ydata(self.mvals)
 
     def plot_resid__time(self, fig, ax):
         lines = ax.get_lines()


### PR DESCRIPTION
## Description

This is a quick hotfix for `gui_fit` (I am a bit sheepish about this). During a fit, the data line is being updated in the plot with the model instead of the model line.

This does not affect the model propagation or fitting, and at the end of the fit the model and data lines are correct, but this should fix the model misleadingly looking like a perfect fit while the fit is running. 


## Testing

- [ x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ x] Functional testing

Fixes #