### PR TITLE
Fix bug in component param set attribute

### DIFF
--- a/xija/component/base.py
+++ b/xija/component/base.py
@@ -80,7 +80,7 @@ class ModelComponent(object):
             return super(ModelComponent, self).__getattribute__(attr)
 
     def __setattr__(self, attr, val):
-        if attr in self.pars:
+        if attr in self.pars_dict:
             self.pars_dict[attr].val = val
         else:
             super(ModelComponent, self).__setattr__(attr, val)

--- a/xija/tests/test_models.py
+++ b/xija/tests/test_models.py
@@ -222,6 +222,14 @@ def test_pftank2t():
     for msid in msids:
         assert np.allclose(mdl.comp[msid].mvals, regr[msid])
 
+    # Test that setattr works for component parameter value by changing one
+    # value and seeing that the model prediction changes substantially.
+    mvals = mdl.comp['pftank2t'].mvals.copy()
+    mdl.comp['solarheat__pf0tank2t'].P_60 = 5.0
+    mdl.calc()
+    mvals2 = mdl.comp['pftank2t'].mvals
+    assert np.any(abs(mvals2 - mvals) > 5)
+
 
 def test_multi_solar_heat_values():
     P_pitches = [45, 180]


### PR DESCRIPTION
## Description

This fixes a 7+ year old bug when trying to do something like:
```
mdl.comp['solarheat__pf0tank2t'].P_60 = 5.0
mdl.calc()
```

Note that a work-around right now is:
```
mdl.comp['solarheat__pf0tank2t'].pars_dict['P_60'] = 5.0
```

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing: New unit testing
