### PR TITLE
Fixes for tests for shiny

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+filterwarnings =
+    # See https://github.com/numpy/numpy/issues/11788 for why this is benign
+    ignore:numpy.ufunc size changed:RuntimeWarning
+    ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
+    ignore:parse functions are required to provide a named argument:PendingDeprecationWarning
+norecursedirs = .* alt_core build ctypes_example dist doc examples GUI_play ipynb models* nmass* pyside tests_no_pytest tmp twodof www

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[pytest]
-norecursedirs = .* alt_core build ctypes_example dist doc examples GUI_play ipynb models* nmass* pyside tests_no_pytest tmp twodof www

--- a/xija/component/experimental.py
+++ b/xija/component/experimental.py
@@ -95,7 +95,7 @@ class SolarHeatSimZ(SolarHeat):
     """Solar heating (pitch and SimZ dependent)"""
     def __init__(self, model, node, simz_comp, pitch_comp, eclipse_comp=None,
                  P_pitches=None, Ps=None, dPs=None, var_func='exp',
-                 tau=1732.0, ampl=0.05, bias=0.0, epoch='2010:001',
+                 tau=1732.0, ampl=0.05, bias=0.0, epoch='2010:001:12:00:00',
                  hrci_bias=0.0, hrcs_bias=0.0, acisi_bias=0.0):
         SolarHeat.__init__(self, model, node, pitch_comp, eclipse_comp,
                            P_pitches, Ps, dPs, var_func, tau, ampl, bias,

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -117,7 +117,7 @@ class SolarHeat(PrecomputedHeatPower):
     """
     def __init__(self, model, node, pitch_comp, eclipse_comp=None,
                  P_pitches=None, Ps=None, dPs=None, var_func='exp',
-                 tau=1732.0, ampl=0.05, bias=0.0, epoch='2010:001'):
+                 tau=1732.0, ampl=0.05, bias=0.0, epoch='2010:001:12:00:00'):
         ModelComponent.__init__(self, model)
         self.node = self.model.get_comp(node)
         self.pitch_comp = self.model.get_comp(pitch_comp)
@@ -283,10 +283,10 @@ class SolarHeat(PrecomputedHeatPower):
 class SolarHeatMulplicative(SolarHeat):
     def __init__(self, model, node, pitch_comp, eclipse_comp=None,
                  P_pitches=None, Ps=None, dPs=None, var_func='exp',
-                 tau=1732.0, ampl=0.0334, bias=0.0, epoch='2010:001'):
+                 tau=1732.0, ampl=0.0334, bias=0.0, epoch='2010:001:12:00:00'):
         super(SolarHeatMulplicative, self).__init__(
             model, node, pitch_comp, eclipse_comp=eclipse_comp,
-            P_pitches=P_pitches, Ps=Ps, dPs=dPs, var_func=var_func, 
+            P_pitches=P_pitches, Ps=Ps, dPs=dPs, var_func=var_func,
             tau=tau, ampl=ampl, bias=bias, epoch=epoch)
 
     def _compute_dvals(self):
@@ -316,7 +316,7 @@ class SolarHeatAcisCameraBody(SolarHeat):
     """
     def __init__(self, model, node, pitch_comp, eclipse_comp=None,
                  P_pitches=None, Ps=None, dPs=None, var_func='exp',
-                 tau=1732.0, ampl=0.05, bias=0.0, epoch='2010:001',
+                 tau=1732.0, ampl=0.05, bias=0.0, epoch='2010:001:12:00:00',
                  dh_heater_comp=None, dh_heater_bias=0.0):
 
         super(SolarHeatAcisCameraBody, self).__init__(
@@ -353,7 +353,7 @@ class SolarHeatHrc(SolarHeat):
     """
     def __init__(self, model, node, simz_comp, pitch_comp, eclipse_comp=None,
                  P_pitches=None, Ps=None, dPs=None, var_func='exp',
-                 tau=1732.0, ampl=0.05, bias=0.0, epoch='2010:001',
+                 tau=1732.0, ampl=0.05, bias=0.0, epoch='2010:001:12:00:00',
                  hrc_bias=0.0):
         SolarHeat.__init__(self, model, node, pitch_comp, eclipse_comp,
                            P_pitches, Ps, dPs, var_func, tau, ampl, bias,
@@ -391,7 +391,7 @@ class SolarHeatHrcOpts(SolarHeat):
     """
     def __init__(self, model, node, simz_comp, pitch_comp, eclipse_comp=None,
                  P_pitches=None, Ps=None, dPs=None, var_func='exp',
-                 tau=1732.0, ampl=0.05, bias=0.0, epoch='2010:001',
+                 tau=1732.0, ampl=0.05, bias=0.0, epoch='2010:001:12:00:00',
                  hrci_bias=0.0, hrcs_bias=0.0):
         SolarHeat.__init__(self, model, node, pitch_comp, eclipse_comp,
                            P_pitches, Ps, dPs, var_func, tau, ampl, bias,
@@ -415,12 +415,12 @@ class SolarHeatHrcOpts(SolarHeat):
 class SolarHeatHrcMult(SolarHeatHrcOpts, SolarHeatMulplicative):
     def __init__(self, model, node, simz_comp, pitch_comp, eclipse_comp=None,
                  P_pitches=None, Ps=None, dPs=None, var_func='exp',
-                 tau=1732.0, ampl=0.0334, bias=0.0, epoch='2010:001',
+                 tau=1732.0, ampl=0.0334, bias=0.0, epoch='2010:001:12:00:00',
                  hrci_bias=0.0, hrcs_bias=0.0):
         super(SolarHeatHrcMult, self).__init__(
             model, node, simz_comp, pitch_comp, eclipse_comp=eclipse_comp,
             P_pitches=P_pitches, Ps=Ps, dPs=dPs, var_func=var_func, tau=tau,
-            ampl=ampl, bias=bias, epoch=epoch, hrci_bias=hrci_bias, 
+            ampl=ampl, bias=bias, epoch=epoch, hrci_bias=hrci_bias,
             hrcs_bias=hrcs_bias)
 
 # For back compatibility prior to Xija 0.2
@@ -608,7 +608,7 @@ class AcisPsmcSolarHeat(PrecomputedHeatPower):
     """Solar heating of PSMC box.  This is dependent on SIM-Z"""
     def __init__(self, model, node, pitch_comp, simz_comp, dh_heater_comp, P_pitches=None,
                  P_vals=None, dPs=None, var_func='linear',
-                 tau=1732.0, ampl=0.05, epoch='2013:001', dh_heater=0.05):
+                 tau=1732.0, ampl=0.05, epoch='2013:001:12:00:00', dh_heater=0.05):
         ModelComponent.__init__(self, model)
         self.n_mvals = 1
         self.node = self.model.get_comp(node)
@@ -833,7 +833,7 @@ class AcisDpaStatePower(PrecomputedHeatPower):
     state.  See dpa/NOTES.power.
     """
     def __init__(self, model, node, mult=1.0,
-                 fep_count=None, ccd_count=None, 
+                 fep_count=None, ccd_count=None,
                  vid_board=None, clocking=None,
                  pow_states=None):
         super(AcisDpaStatePower, self).__init__(model)
@@ -927,7 +927,7 @@ class AcisDpaStatePower(PrecomputedHeatPower):
         else:
             plot_cxctime(self.model.times, powers, ls='-',
                          color='#d92121', fig=fig, ax=ax)
-            plot_cxctime(self.model.times, self.dvals, 
+            plot_cxctime(self.model.times, self.dvals,
                          color='#386cb0', ls='-', fig=fig, ax=ax)
             ax.grid()
             ax.set_title('{}: model (red) and data (blue)'.format(self.name))
@@ -1013,7 +1013,7 @@ class ThermostatHeater(ActiveHeatPower):
 
 class StepFunctionPower(PrecomputedHeatPower):
     """
-    A class that applies a constant temperature shift only 
+    A class that applies a constant temperature shift only
     after a certain point in time.
     """
     def __init__(self, model, node, time, P=0.0):

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -506,7 +506,10 @@ class EarthHeat(PrecomputedHeatPower):
                           for x in ('x', 'y', 'z')]
             aoattqt_1234s = [getattr(self, 'aoattqt{}'.format(x))
                              for x in range(1, 5)]
-            ephems = np.array([x.dvals for x in ephem_xyzs]).transpose()
+            # Note: the copy() here is so that the array becomes contiguous in
+            # memory and allows numba to run faster (and avoids NumbaPerformanceWarning:
+            # np.dot() is faster on contiguous arrays).
+            ephems = np.array([x.dvals for x in ephem_xyzs]).transpose().copy()
             q_atts = np.array([x.dvals for x in aoattqt_1234s]).transpose()
 
             # Q_atts can have occasional bad values, maybe because the

--- a/xija/tests/test_models.py
+++ b/xija/tests/test_models.py
@@ -149,9 +149,7 @@ def test_dpa():
 
     regr = np.load(reffile)
     assert np.allclose(mdl.times, regr['times'], rtol=0, atol=1e-3)
-    print('DPA', np.max(np.abs(dpa.dvals - regr['dvals'])))
     assert np.allclose(dpa.dvals, regr['dvals'])
-    print('DPA', np.max(np.abs(dpa.mvals - regr['mvals'])))
     assert np.allclose(dpa.mvals, regr['mvals'])
 
 
@@ -197,7 +195,6 @@ def test_minusz():
     regr = np.load(regrfile)
     assert np.allclose(mdl.times, regr['times'])
     for msid in msids:
-        print(msid, np.max(np.abs(mdl.comp[msid].mvals - regr[msid])))
         assert np.allclose(mdl.comp[msid].mvals, regr[msid])
 
 
@@ -223,7 +220,6 @@ def test_pftank2t():
     regr = np.load(regrfile)
     assert np.allclose(mdl.times, regr['times'])
     for msid in msids:
-        print(msid, np.max(np.abs(mdl.comp[msid].mvals - regr[msid])))
         assert np.allclose(mdl.comp[msid].mvals, regr[msid])
 
     # Test that setattr works for component parameter value by changing one

--- a/xija/tests/test_models.py
+++ b/xija/tests/test_models.py
@@ -26,7 +26,7 @@ def abs_path(spec):
 
 
 def test_dpa_real():
-    mdl = ThermalModel('dpa', start='2012:001', stop='2012:007',
+    mdl = ThermalModel('dpa', start='2012:001:12:00:00', stop='2012:007:12:00:00',
                        model_spec=abs_path('dpa.json'))
     # Check that cmd_states database can be read.  Skip if not, probably
     # running test on a platform without access.
@@ -57,7 +57,7 @@ def test_pitch_clip():
     has been modified so the solarheat pitch range is from 55 .. 153.
     Make sure the model still runs with no interpolation error.
     """
-    mdl = ThermalModel('dpa', start='2012:001', stop='2012:007',
+    mdl = ThermalModel('dpa', start='2012:001:12:00:00', stop='2012:007:12:00:00',
                        model_spec=abs_path('dpa_clip.json'))
     try:
         mdl._get_cmd_states()
@@ -78,7 +78,7 @@ def test_pitch_range_clip():
     Make sure the pitch range stored does not include values outside of the 45
     to 180 degree range.
     """
-    mdl = ThermalModel('tank', start='2019:120', stop='2019:122',
+    mdl = ThermalModel('tank', start='2019:120:12:00:00', stop='2019:122:12:00:00',
                        model_spec=abs_path('pftank2t.json'))
 
     mdl.comp['pf0tank2t'].set_data(20.0)
@@ -91,7 +91,7 @@ def test_pitch_range_clip():
 
 
 def test_dpa_remove_pow():
-    mdl = ThermalModel('dpa', start='2012:001', stop='2012:007',
+    mdl = ThermalModel('dpa', start='2012:001:12:00:00', stop='2012:007:12:00:00',
                        model_spec=abs_path('dpa_remove_pow.json'))
     # Check that cmd_states database can be read.  Skip if not, probably
     # running test on a platform without access.
@@ -116,7 +116,7 @@ def test_dpa_remove_pow():
     assert np.allclose(dpa.mvals, regr['mvals'])
 
 def get_dpa_model():
-    mdl = ThermalModel('dpa', start='2012:001', stop='2012:007',
+    mdl = ThermalModel('dpa', start='2012:001:12:00:00', stop='2012:007:12:00:00',
                             model_spec=abs_path('dpa.json'))
     times = (mdl.times - mdl.times[0]) / 10000.0
     mdl.comp['1dpamzt'].set_data(30.0)
@@ -148,8 +148,10 @@ def test_dpa():
                  mvals=dpa.mvals)
 
     regr = np.load(reffile)
-    assert np.allclose(mdl.times, regr['times'])
+    assert np.allclose(mdl.times, regr['times'], rtol=0, atol=1e-3)
+    print('DPA', np.max(np.abs(dpa.dvals - regr['dvals'])))
     assert np.allclose(dpa.dvals, regr['dvals'])
+    print('DPA', np.max(np.abs(dpa.mvals - regr['mvals'])))
     assert np.allclose(dpa.mvals, regr['mvals'])
 
 
@@ -162,7 +164,7 @@ def test_plotdate():
 
 def test_data_types():
     for data_type in (int, float, np.float32, np.float64, np.int32, np.int64, np.complex64):
-        mdl = ThermalModel('dpa', start='2012:001', stop='2012:007',
+        mdl = ThermalModel('dpa', start='2012:001:12:00:00', stop='2012:007:12:00:00',
                            model_spec=abs_path('dpa.json'))
         dpa = mdl.comp['1dpamzt']
         dpa.set_data(data_type(30.0))
@@ -174,7 +176,7 @@ def test_data_types():
 
 
 def test_minusz():
-    mdl = ThermalModel('minusz', start='2012:001', stop='2012:004',
+    mdl = ThermalModel('minusz', start='2012:001:12:00:00', stop='2012:004:12:00:00',
                        model_spec=abs_path('minusz.json'))
     times = (mdl.times - mdl.times[0]) / 10000.0
     msids = ('tephin', 'tcylaft6', 'tcylfmzm', 'tmzp_my', 'tfssbkt1')
@@ -195,11 +197,12 @@ def test_minusz():
     regr = np.load(regrfile)
     assert np.allclose(mdl.times, regr['times'])
     for msid in msids:
+        print(msid, np.max(np.abs(mdl.comp[msid].mvals - regr[msid])))
         assert np.allclose(mdl.comp[msid].mvals, regr[msid])
 
 
 def test_pftank2t():
-    mdl = ThermalModel('pftank2t', start='2012:001', stop='2012:004',
+    mdl = ThermalModel('pftank2t', start='2012:001:12:00:00', stop='2012:004:12:00:00',
                        model_spec=abs_path('pftank2t.json'))
     times = (mdl.times - mdl.times[0]) / 10000.0
     msids = ('pftank2t', 'pf0tank2t')
@@ -220,6 +223,7 @@ def test_pftank2t():
     regr = np.load(regrfile)
     assert np.allclose(mdl.times, regr['times'])
     for msid in msids:
+        print(msid, np.max(np.abs(mdl.comp[msid].mvals - regr[msid])))
         assert np.allclose(mdl.comp[msid].mvals, regr[msid])
 
     # Test that setattr works for component parameter value by changing one
@@ -237,7 +241,7 @@ def test_multi_solar_heat_values():
     P_pitches2 = [45, 65, 90, 140, 180]
     P_vals2 = [1.0, 1.0, 0.0, 1.0, 1.0]
 
-    model = ThermalModel('test', start='2011:001', stop='2011:005')
+    model = ThermalModel('test', start='2011:001:12:00:00', stop='2011:005:12:00:00')
     tephin = model.add(Node, 'tephin')
     tcylaft6 = model.add(Node, 'tcylaft6')
     pitch = model.add(Pitch)
@@ -273,7 +277,7 @@ def test_multi_solar_heat_values():
     temp_name = tempfile.NamedTemporaryFile(delete=False).name
     model.write(temp_name)
     model2 = ThermalModel('test', model_spec=temp_name,
-                          start='2011:001', stop='2011:005')
+                          start='2011:001:12:00:00', stop='2011:005:12:00:00')
     os.unlink(temp_name)
     model2.get_comp('tephin').set_data(30.0)
     model2.get_comp('tcylaft6').set_data(30.0)


### PR DESCRIPTION
## Description

This changes epoch dates like `2010:001` to a fully-qualified string like `2010:001:12:00:00` so regression tests all pass in shiny with Chandra.Time 4.0+.

It also includes the standard pytest filters to ignore useless warnings.

See also: https://github.com/sot/skare3/wiki/Shiny-Ska3

## Testing

- [x] Passes unit tests on MacOS (shiny)
- [x] Passes unit tests on MacOS (flight)
- [N/A] Functional testing
