### PR TITLE
Enhance StepFunctionPower component to allow multiple instances

### DIFF
--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -1013,18 +1013,26 @@ class ThermostatHeater(ActiveHeatPower):
 
 class StepFunctionPower(PrecomputedHeatPower):
     """
-    A class that applies a constant temperature shift only 
-    after a certain point in time.
+    A class that applies a constant heat power shift only
+    after a certain point in time.  The shift is 0.0 before
+    ``time`` and ``P`` after ``time``.
+
+    :param model: parent model object
+    :param node: node name or object for which to apply shift
+    :param time: time of step function shift
+    :param P: size of shift in heat power (default=0.0)
+    :param id: str, identifier to allow multiple steps (default='')
     """
-    def __init__(self, model, node, time, P=0.0):
+    def __init__(self, model, node, time, P=0.0, id=''):
         super(StepFunctionPower, self).__init__(model)
         self.time = DateTime(time).secs
         self.node = self.model.get_comp(node)
-        self.add_par('P', P, min=-10.0, max=10.0)
         self.n_mvals = 1
+        self.id = id
+        self.add_par('P', P, min=-10.0, max=10.0)
 
     def __str__(self):
-        return 'step_power__{0}'.format(self.node)
+        return f'step_power{self.id}__{self.node}'
 
     def get_dvals_tlm(self):
         """Return an array of zeros => no activation of the heater.


### PR DESCRIPTION
## Description

This allows including multiple instances of the StepFunctionPower component on the same node by adding an `id` attribute. This identifier is put into the component name (via the __str__ function). The default `id` is an empty string for back-compatibility.

**Reminder**: this needs to be ported to the `shiny` branch (by cherry-pick or rebase).

To make the model more self-documenting, I would recommend setting the `id` to be the date of the step, for instance `_2020213` for the July 31 swap.

## Approval

Reviewed and approved by TWG on July 21, 2020.

## Testing

- [x] Passes unit tests on MacOS (ska3-flight)
- [x] Functional testing

### Functional

Made a new ACA model `aca_spec_3_step` which has a step function up at 2020:100 and same step function back down at 2020:120. This shows that the additional step functions are having the intended effect:
- No impact on model predictions prior to 2020:100
- Model prediction jumps up at 2020:100
- Model prediction jumps back down to original level at 2020:120

![image](https://user-images.githubusercontent.com/348089/87929438-6d6ac980-ca54-11ea-89f9-deaed66a1e0a.png)

The new model spec as Python looks like:
```
model.add(xija.StepFunctionPower,
          node='aca0',
          time='2020:100:00:00:00',
          P=0.1,
          id='_2'
         )
model.add(xija.StepFunctionPower,
          node='aca0',
          time='2020:120:00:00:00',
          P=-0.1,
          id='_3'
         )
```
and as JSON:
```
        {
            "class_name": "StepFunctionPower",
            "init_args": [],
            "init_kwargs": {
                "P": 0.1,
                "id": "_2",
                "node": "aca0",
                "time": "2020:100:00:00:00"
            },
            "name": "step_power_2__aca0"
        },
        {
            "class_name": "StepFunctionPower",
            "init_args": [],
            "init_kwargs": {
                "P": -0.1,
                "id": "_3",
                "node": "aca0",
                "time": "2020:120:00:00:00"
            },
            "name": "step_power_3__aca0"
        }
```
