### PR TITLE
Add module to allow getting model spec files from Ska data

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,3 +27,9 @@ Mask classes
 
 .. automodule:: xija.component.mask
    :members:
+
+Get model spec
+--------------
+.. automodule:: xija.get_model_spec
+   :members:
+

--- a/xija/get_model_spec.py
+++ b/xija/get_model_spec.py
@@ -39,12 +39,23 @@ def get_xija_model_spec(model_name, version=None, repo_path=REPO_PATH,
 
     Examples
     --------
+    Get the latest version of the ``acisfp`` model spec from the local Ska data
+    directory ``$SKA/data/chandra_models``, checking that the version matches
+    the latest release tag on GitHub.
+
     >>> import xija
     >>> from xija.get_model_spec import get_xija_model_spec
-    >>> model_spec = get_xija_model_spec('acisfp')
-    >>> model = xija.XijaModel('acisfp', model_spec=model_spec, start='2012:001', stop='2012:010')
+    >>> model_spec, version = get_xija_model_spec('acisfp', check_version=True)
+    >>> model = xija.XijaModel('acisfp', model_spec=model_spec,
+    ...                        start='2012:001', stop='2012:010')
     >>> model.make()
     >>> model.calc()
+
+    Get the ``aca`` model spec from release version 3.30 of chandra_models from
+    GitHub.
+
+    >>> repo_path = 'https://github.com/sot/chandra_models.git'
+    >>> model_spec, version = get_xija_model_spec('aca', version='3.30', repo_path=repo_path)
 
     Parameters
     ----------
@@ -64,16 +75,16 @@ def get_xija_model_spec(model_name, version=None, repo_path=REPO_PATH,
 
     Returns
     -------
-    dict
-        Xija model specification dict
+    dict, str
+        Xija model specification dict, chandra_models version
     """
     with tempfile.TemporaryDirectory() as repo_path_local:
         repo = git.Repo.clone_from(repo_path, repo_path_local)
         if version is not None:
             repo.git.checkout(version)
-        spec = _get_xija_model_spec(model_name, version, repo_path_local, check_version, timeout)
-
-    return spec
+        model_spec, version = _get_xija_model_spec(model_name, version, repo_path_local,
+                                                   check_version, timeout)
+    return model_spec, version
 
 
 def _get_xija_model_spec(model_name, version=None, repo_path=REPO_PATH,
@@ -108,7 +119,7 @@ def _get_xija_model_spec(model_name, version=None, repo_path=REPO_PATH,
             raise ValueError(f'version mismatch: local repo {version} vs '
                              f'github {gh_version}')
 
-    return model_spec
+    return model_spec, version
 
 
 def get_xija_model_names(repo_path=REPO_PATH) -> List[str]:

--- a/xija/get_model_spec.py
+++ b/xija/get_model_spec.py
@@ -47,7 +47,7 @@ def get_xija_model_spec(model_name, version=None, repo_path=REPO_PATH,
     >>> from xija.get_model_spec import get_xija_model_spec
     >>> model_spec, version = get_xija_model_spec('acisfp', check_version=True)
     >>> model = xija.XijaModel('acisfp', model_spec=model_spec,
-    ...                        start='2012:001', stop='2012:010')
+    ...                        start='2020:001', stop='2020:010')
     >>> model.make()
     >>> model.calc()
 
@@ -55,7 +55,8 @@ def get_xija_model_spec(model_name, version=None, repo_path=REPO_PATH,
     GitHub.
 
     >>> repo_path = 'https://github.com/sot/chandra_models.git'
-    >>> model_spec, version = get_xija_model_spec('aca', version='3.30', repo_path=repo_path)
+    >>> model_spec, version = get_xija_model_spec('aca', version='3.30',
+    ...                                           repo_path=repo_path)
 
     Parameters
     ----------

--- a/xija/get_model_spec.py
+++ b/xija/get_model_spec.py
@@ -1,0 +1,164 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Get Chandra model specifications
+"""
+import os
+import re
+from pathlib import Path
+from typing import List, Optional
+
+from git import Repo
+import requests
+from Ska.File import get_globfiles
+
+__all__ = ['get_xija_model_file', 'get_xija_model_names', 'get_repo_version',
+           'check_github_version']
+
+REPO_PATH = Path(os.environ['SKA'], 'data', 'chandra_models')
+MODELS_PATH = REPO_PATH / 'chandra_models' / 'xija'
+CHANDRA_MODELS_URL = 'https://api.github.com/repos/sot/chandra_models/releases'
+
+
+def get_xija_model_file(model_name, models_path=MODELS_PATH) -> str:
+    """
+    Get file name of Xija model specification for the specified ``model_name``.
+
+    Supported model names include (but are not limited to): ``'aca'``,
+    ``'acisfp'``, ``'dea'``, ``'dpa'``, ``'psmc'``, ``'minusyz'``, and
+    ``'pftank2t'``.
+
+    Use ``get_xija_model_names()`` for the full list.
+
+    Examples
+    --------
+    >>> import xija
+    >>> from xija.get_model_spec import get_xija_model_file
+    >>> model_spec = get_xija_model_file('acisfp')
+    >>> model = xija.XijaModel('acisfp', model_spec=model_spec, start='2012:001', stop='2012:010')
+    >>> model.make()
+    >>> model.calc()
+
+    Parameters
+    ----------
+    model_name : str
+        Name of model
+    models_path : str, Path
+        Path to directory containing xija model spec files (default is
+        $SKA/data/chandra_models)
+
+    Returns
+    -------
+    str
+        File name of the corresponding Xija model specification
+    """
+    models_path = Path(models_path)
+
+    if not models_path.exists():
+        raise FileNotFoundError(f'xija models directory {models_path} does not exist')
+
+    file_glob = str(models_path / '*' / f'{model_name.lower()}_spec.json')
+    try:
+        # get_globfiles() default requires exactly one file match and returns a list
+        file_name = get_globfiles(file_glob)[0]
+    except ValueError:
+        names = get_xija_model_names()
+        raise ValueError(f'no models matched {model_name}. Available models are: '
+                         f'{", ".join(names)}')
+
+    return file_name
+
+
+def get_xija_model_names(models_path=MODELS_PATH) -> List[str]:
+    """Return list of available xija model names.
+
+    Parameters
+    ----------
+    models_path : str, Path
+        Path to directory containing xija model spec files (default is
+        $SKA/data/chandra_models)
+
+    Examples
+    --------
+    >>> from xija.get_model_spec import get_xija_model_names
+    >>> names = get_xija_model_names()
+    ['aca',
+     'acisfp',
+     'dea',
+     'dpa',
+     '4rt700t',
+     'minusyz',
+     'pm1thv2t',
+     'pm2thv1t',
+     'pm2thv2t',
+     'pftank2t',
+     'pline03t_model',
+     'pline04t_model',
+     'psmc',
+     'tcylaft6']
+
+    Returns
+    -------
+    list
+        List of available xija model names
+    """
+    models_path = Path(models_path)
+
+    fns = get_globfiles(str(models_path / '*' / '*_spec.json'), minfiles=0, maxfiles=None)
+    names = [re.sub(r'_spec\.json', '', Path(fn).name) for fn in sorted(fns)]
+
+    return names
+
+
+def get_repo_version() -> str:
+    """Return version (most recent tag) of models repository.
+
+    Returns
+    -------
+    str
+        Version (most recent tag) of models repository
+    """
+    repo = Repo(REPO_PATH)
+
+    if repo.is_dirty():
+        raise ValueError('repo is dirty')
+
+    tags = sorted(repo.tags, key=lambda tag: tag.commit.committed_datetime)
+    tag_repo = tags[-1]
+    if tag_repo.commit != repo.head.commit:
+        raise ValueError(f'repo tip is not at tag {tag_repo}')
+
+    return tag_repo.name
+
+
+def check_github_version(tag_name, url=CHANDRA_MODELS_URL, timeout=5) -> Optional[bool]:
+    """Check that latest chandra_models GitHub repo release matches ``tag_name``.
+
+    This queries GitHub for the latest release of chandra_models.
+
+    Parameters
+    ----------
+    tag_name : str
+        Tag name e.g. '3.32'
+    url : str
+        URL for chandra_models releases on GitHub API
+    timeout : int, float
+        Request timeout (sec, default=5)
+
+    Returns
+    -------
+    bool, None
+        True if chandra_models release on GitHub matches tag_name.
+        None if the request timed out, indicating indeterminate answer.
+    """
+    try:
+        req = requests.get(url, timeout=timeout)
+    except requests.ConnectTimeout:
+        return None
+
+    if req.status_code != requests.codes.ok:
+        req.raise_for_status()
+
+    tags_gh = sorted(req.json(), key=lambda tag: tag['published_at'])
+    tag_gh_name = tags_gh[-1]['tag_name']
+
+    return tag_gh_name == tag_name

--- a/xija/tests/test_get_model_spec.py
+++ b/xija/tests/test_get_model_spec.py
@@ -7,7 +7,7 @@ import re
 import pytest
 import requests
 
-from ..get_model_spec import (get_xija_model_file, get_xija_model_names,
+from ..get_model_spec import (get_xija_model_spec, get_xija_model_names,
                               get_repo_version, get_github_version)
 
 try:
@@ -18,20 +18,18 @@ except Exception:
     HAS_GITHUB = False
 
 
-def test_get_model_file_aca():
-    fn = get_xija_model_file('aca', check_version=HAS_GITHUB)
-    assert fn.startswith(os.environ['SKA'])
-    assert Path(fn).name == 'aca_spec.json'
-    spec = json.load(open(fn))
+def test_get_model_spec_aca():
+    spec = get_xija_model_spec('aca', check_version=HAS_GITHUB)
     assert spec['name'] == 'aacccdpt'
+    assert 'comps' in spec
 
 
 def test_get_model_file_fail():
     with pytest.raises(ValueError, match='no models matched xxxyyyzzz'):
-        get_xija_model_file('xxxyyyzzz')
+        get_xija_model_spec('xxxyyyzzz')
 
     with pytest.raises(FileNotFoundError, match='xija models directory'):
-        get_xija_model_file('aca', repo_path='__NOT_A_DIRECTORY__')
+        get_xija_model_spec('aca', repo_path='__NOT_A_DIRECTORY__')
 
 
 def test_get_xija_model_names():

--- a/xija/tests/test_get_model_spec.py
+++ b/xija/tests/test_get_model_spec.py
@@ -10,6 +10,7 @@ from ..get_model_spec import (get_xija_model_spec, get_xija_model_names,
                               get_repo_version, get_github_version)
 
 try:
+    # Fast request to see if GitHub is available
     req = requests.get('https://raw.githubusercontent.com/sot/chandra_models/master/README',
                        timeout=5)
     HAS_GITHUB = req.status_code == 200
@@ -17,9 +18,30 @@ except Exception:
     HAS_GITHUB = False
 
 
-def test_get_model_spec_aca():
-    spec = get_xija_model_spec('aca', check_version=HAS_GITHUB)
+def test_get_model_spec_aca_3_30():
+    # Version 3.30
+    spec, version = get_xija_model_spec('aca', version='3.30')
     assert spec['name'] == 'aacccdpt'
+    assert 'comps' in spec
+    assert spec["datestop"] == "2018:305:11:52:30.816"
+
+
+def test_get_model_spec_aca_latest():
+    # Latest version
+    spec, version = get_xija_model_spec('aca', check_version=HAS_GITHUB)
+    assert spec['name'] == 'aacccdpt'
+    # version 3.30 value, changed in 3.31.1/3.32
+    assert spec["datestop"] != "2018:305:11:52:30.816"
+    assert 'comps' in spec
+
+
+@pytest.mark.skipif('not HAS_GITHUB')
+def test_get_model_spec_aca_from_github():
+    # Latest version
+    repo_path = 'https://github.com/sot/chandra_models.git'
+    spec, version = get_xija_model_spec('aca', repo_path=repo_path, version='3.30')
+    assert spec['name'] == 'aacccdpt'
+    assert spec["datestop"] == "2018:305:11:52:30.816"
     assert 'comps' in spec
 
 

--- a/xija/tests/test_get_model_spec.py
+++ b/xija/tests/test_get_model_spec.py
@@ -1,11 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
-import json
-from pathlib import Path
 import re
+
 import pytest
 import requests
+import git
 
 from ..get_model_spec import (get_xija_model_spec, get_xija_model_names,
                               get_repo_version, get_github_version)
@@ -28,7 +27,7 @@ def test_get_model_file_fail():
     with pytest.raises(ValueError, match='no models matched xxxyyyzzz'):
         get_xija_model_spec('xxxyyyzzz')
 
-    with pytest.raises(FileNotFoundError, match='chandra_models repository'):
+    with pytest.raises(git.GitCommandError, match='does not exist'):
         get_xija_model_spec('aca', repo_path='__NOT_A_DIRECTORY__')
 
 

--- a/xija/tests/test_get_model_spec.py
+++ b/xija/tests/test_get_model_spec.py
@@ -1,0 +1,54 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import os
+import json
+from pathlib import Path
+import re
+import pytest
+import requests
+
+from ..get_model_spec import (get_xija_model_file, get_xija_model_names,
+                              get_repo_version, check_github_version)
+
+
+def test_get_model_file_aca():
+    fn = get_xija_model_file('aca')
+    assert fn.startswith(os.environ['SKA'])
+    assert Path(fn).name == 'aca_spec.json'
+    spec = json.load(open(fn))
+    assert spec['name'] == 'aacccdpt'
+
+
+def test_get_model_file_fail():
+    with pytest.raises(ValueError, match='no models matched xxxyyyzzz'):
+        get_xija_model_file('xxxyyyzzz')
+
+    with pytest.raises(FileNotFoundError, match='xija models directory'):
+        get_xija_model_file('aca', models_path='__NOT_A_DIRECTORY__')
+
+
+def test_get_xija_model_names():
+    names = get_xija_model_names()
+    assert all(name in names for name in ('aca', 'acisfp', 'dea', 'dpa', 'pftank2t'))
+
+
+def test_get_repo_version():
+    version = get_repo_version()
+    assert isinstance(version, str)
+    assert re.match(r'^[0-9.]+$', version)
+
+
+def test_check_github_version():
+    version = get_repo_version()
+    status = check_github_version(version)
+    assert status is True
+
+    status = check_github_version('asdf')
+    assert status is False
+
+    # Force timeout
+    status = check_github_version(version, timeout=0.00001)
+    assert status is None
+
+    with pytest.raises(requests.ConnectionError):
+        check_github_version(version, 'https://______bad_url______')

--- a/xija/tests/test_get_model_spec.py
+++ b/xija/tests/test_get_model_spec.py
@@ -24,7 +24,7 @@ def test_get_model_file_fail():
         get_xija_model_file('xxxyyyzzz')
 
     with pytest.raises(FileNotFoundError, match='xija models directory'):
-        get_xija_model_file('aca', models_path='__NOT_A_DIRECTORY__')
+        get_xija_model_file('aca', repo_path='__NOT_A_DIRECTORY__')
 
 
 def test_get_xija_model_names():

--- a/xija/tests/test_get_model_spec.py
+++ b/xija/tests/test_get_model_spec.py
@@ -28,7 +28,7 @@ def test_get_model_file_fail():
     with pytest.raises(ValueError, match='no models matched xxxyyyzzz'):
         get_xija_model_spec('xxxyyyzzz')
 
-    with pytest.raises(FileNotFoundError, match='xija models directory'):
+    with pytest.raises(FileNotFoundError, match='chandra_models repository'):
         get_xija_model_spec('aca', repo_path='__NOT_A_DIRECTORY__')
 
 


### PR DESCRIPTION
## Description

This adds functions that allow reliably getting xija model spec files from `$SKA/data/chandra_models`. 

By "reliable", the intent is that this will be used in production load review code, replacing the current practice of embedding the spec files into load review code.

The key benefit is allowing more agile xija model updates without requiring code updates and a full Ska3 release. The concept of allowing xija model updates without a code release has been put into practice for MATLAB tools, so extending this to SOT tools seems natural.

Along with this we need the following:
- Clone of the latest flight-approved models git repository in `$SKA/data/chandra_models`
- Process to keep this repo up to date. This can be a manual process that is documented in the Xija model update procedure on the TWG TWiki.  E.g. a Ska admin will keep this checked out at the latest release tag (which by virtue of the model update process guarantees the latest approved flight models).
- Functionality to verify the integrity (repo is clean and at the release tag). This is in the current module.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing (new tests)
