### PR TITLE
Migrate all doc strings to use numpydoc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,7 +149,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,8 @@ from xija import __version__
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 
+autosummary_generate = True
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.imgmath',
     'sphinx.ext.viewcode',
+    'numpydoc',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,10 @@ extensions = [
     'numpydoc',
 ]
 
+# Don't show summaries of the members in each class along with the
+# class' docstring
+numpydoc_show_class_members = False
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/xija/__init__.py
+++ b/xija/__init__.py
@@ -8,8 +8,18 @@ from .files import files
 __version__ = ska_helpers.get_version(__package__)
 
 def test(*args, **kwargs):
-    '''
-    Run py.test unit tests.
-    '''
+    """Run py.test unit tests.
+
+    Parameters
+    ----------
+    *args :
+        
+    **kwargs :
+        
+
+    Returns
+    -------
+
+    """
     import testr
     return testr.test(*args, **kwargs)

--- a/xija/clogging.py
+++ b/xija/clogging.py
@@ -13,30 +13,44 @@ def config_logger(name, format='%(message)s', datefmt=None,
                   stream=sys.stdout, level=logging.INFO,
                   filename=None, filemode='w', filelevel=None,
                   propagate=False):
-    """
-    Do basic configuration for the logging system. Similar to
+    """Do basic configuration for the logging system. Similar to
     logging.basicConfig but the logger ``name`` is configurable and both a file
     output and a stream output can be created. Returns a logger object.
-
+    
     The default behaviour is to create a StreamHandler which writes to
     sys.stdout, set a formatter using the "%(message)s" format string, and
     add the handler to the ``name`` logger.
-
+    
     A number of optional keyword arguments may be specified, which can alter
     the default behaviour.
 
-    :param name: Logger name
-    :param format: handler format string
-    :param datefmt: handler date/time format specifier
-    :param stream: initialize the StreamHandler using ``stream``
-            (None disables the stream, default=sys.stdout)
-    :param level: logger level (default=INFO).
-    :param filename: create FileHandler using ``filename`` (default=None)
-    :param filemode: open ``filename`` with specified filemode ('w' or 'a')
-    :param filelevel: logger level for file logger (default=``level``)
-    :param propagate: propagate message to parent (default=False)
+    Parameters
+    ----------
+    name :
+        Logger name
+    format :
+        handler format string (Default value = '%(message)s')
+    datefmt :
+        handler date/time format specifier (Default value = None)
+    stream :
+        initialize the StreamHandler using ``stream``
+        (None disables the stream, default=sys.stdout)
+    level :
+        logger level (default=INFO).
+    filename :
+        create FileHandler using ``filename`` (default=None)
+    filemode :
+        open ``filename`` with specified filemode ('w' or 'a') (Default value = 'w')
+    filelevel :
+        logger level for file logger (default=``level``)
+    propagate :
+        propagate message to parent (default=False)
 
-    :returns: logging.Logger object
+    Returns
+    -------
+    type
+        logging.Logger object
+
     """
     # Get a logger for the specified name
     logger = logging.getLogger(name)

--- a/xija/component/base.py
+++ b/xija/component/base.py
@@ -12,7 +12,15 @@ from .. import tmal
 
 class Param(dict):
     """Model component parameter.  Inherits from dict but adds attribute access
-    for convenience."""
+    for convenience.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
+    """
     def __init__(self, comp_name, name, val, min=-1e38, max=1e38,
                  fmt="{:.4g}", frozen=False):
         dict.__init__(self)
@@ -63,9 +71,7 @@ class ModelComponent(object):
         self.pars.append(param)
 
     def _getAttributeNames(self):
-        """
-        Add dynamic attribute names for IPython completer.
-        """
+        """Add dynamic attribute names for IPython completer."""
         return [par.name for par in self.pars]
 
     def __getattr__(self, attr):
@@ -190,21 +196,35 @@ class CmdStatesData(TelemData):
 
 class Node(TelemData):
     """Time-series dataset for prediction.
-
+    
     If the ``sigma`` value is negative then sigma is computed from the
     node data values as the specified percent of the data standard
     deviation.  The default ``sigma`` value is -10, so this implies
     using a sigma of 10% of the data standard deviation.  If ``sigma``
     is set to 0 then the fit statistic is set to 0.0 for this node.
 
-    :param model: parent model
-    :param msid: MSID for telemetry data
-    :param name: component name (default=``msid``)
-    :param sigma: sigma value used in chi^2 fit statistic
-    :param quant: use quantized stats (not currently implemented)
-    :param predict: compute prediction for this node (default=True)
-    :param mask: Mask component for masking values from fit statistic
-    :param data: Node data (None or a single value)
+    Parameters
+    ----------
+    model :
+        parent model
+    msid :
+        MSID for telemetry data
+    name :
+        component name (default=``msid``)
+    sigma :
+        sigma value used in chi^2 fit statistic
+    quant :
+        use quantized stats (not currently implemented)
+    predict :
+        compute prediction for this node (default=True)
+    mask :
+        Mask component for masking values from fit statistic
+    data :
+        Node data (None or a single value)
+
+    Returns
+    -------
+
     """
     def __init__(self, model, msid, sigma=-10, quant=None,
                  predict=True, mask=None, name=None, data=None,
@@ -224,6 +244,13 @@ class Node(TelemData):
     def randx(self):
         """Random X-offset for plotting which is a uniform distribution
         with width = self.quant or 1.0
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         if not hasattr(self, '_randx'):
             dx = self.quant or 1.0
@@ -307,8 +334,15 @@ class Coupling(ModelComponent):
     """\
     First-order coupling between Nodes `node1` and `node2`
     ::
-
+    
       dy1/dt = -(y1 - y2) / tau
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
     def __init__(self, model, node1, node2, tau):
         ModelComponent.__init__(self, model)
@@ -350,14 +384,21 @@ class HeatSinkRef(ModelComponent):
     tau does not affect the mean model temperature.  This requires an extra
     non-fitted parameter T_ref which corresponds to a reference temperature for
     the node.::
-
+    
       dT/dt = U * (Te - T)
             = P + U* (T_ref - T)   # reparameterization
-
+    
       P = U * (Te - T_ref)
       Te = P / U + T_ref
-
+    
     In code below, "T" corresponds to "Te" above.  The "T" above is node.dvals.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
     def __init__(self, model, node, T=0.0, tau=20.0, T_ref=20.0):
         ModelComponent.__init__(self, model)
@@ -399,6 +440,13 @@ class Pitch(TelemData):
 class AcisFPtemp(Node):
     """Make a wrapper around MSID FPTEMP_11 because that currently comes from
     the eng_archive in K instead of C.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
     def __init__(self, model, mask=None):
         Node.__init__(self, model, 'fptemp_11', mask=mask)

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -47,22 +47,36 @@ class PrecomputedHeatPower(ModelComponent):
 
 class ActiveHeatPower(ModelComponent):
     """Component that provides active heat power input which depends on
-    current or past computed model values"""
+    current or past computed model values
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
+    """
     pass
 
 
 class SolarHeatOffNomRoll(PrecomputedHeatPower):
-    """
-    Heating of a +Y or -Y face of a spacecraft component due to off-nominal roll.  The
+    """Heating of a +Y or -Y face of a spacecraft component due to off-nominal roll.  The
     heating is proportional to the projection of the sun on body +Y axis (which is a value
     from -1 to 1).  There are two parameters ``P_plus_y`` and ``P_minus_y``.  For sun on
     the +Y side the ``P_plus_y`` parameter is used, and likewise for sun on -Y.  For
     example for +Y sun::
-
+    
        heat = P_plus_y * sun_body_y
-
+    
     The following reference has useful diagrams concerning off-nominal roll and
     projections: http://occweb.cfa.harvard.edu/twiki/pub/Aspect/WebHome/ROLLDEV3.pdf.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(self, model, node, pitch_comp, roll_comp, eclipse_comp=None,
@@ -102,18 +116,36 @@ class SolarHeatOffNomRoll(PrecomputedHeatPower):
 class SolarHeat(PrecomputedHeatPower):
     """Solar heating (pitch dependent)
 
-    :param model: parent model
-    :param node: node which is coupled to solar heat
-    :param pitch_comp: solar Pitch component
-    :param eclipse_comp: Eclipse component (optional)
-    :param P_pitches: list of pitch values (default=[45, 65, 90, 130, 180])
-    :param Ps: list of solar heating values (default=[1.0, ...])
-    :param dPs: list of delta heating values (default=[0.0, ...])
-    :param var_func: variability function ('exp' | 'linear')
-    :param tau: variability timescale (days)
-    :param ampl: ampl of annual sinusoidal heating variation
-    :param bias: constant offset to all solar heating values
-    :param epoch: reference date at which ``Ps`` values apply
+    Parameters
+    ----------
+    model :
+        parent model
+    node :
+        node which is coupled to solar heat
+    pitch_comp :
+        solar Pitch component
+    eclipse_comp :
+        Eclipse component (optional)
+    P_pitches :
+        list of pitch values (default=[45, 65, 90, 130, 180])
+    Ps :
+        list of solar heating values (default=[1.0, ...])
+    dPs :
+        list of delta heating values (default=[0.0, ...])
+    var_func :
+        variability function ('exp' | 'linear')
+    tau :
+        variability timescale (days)
+    ampl :
+        ampl of annual sinusoidal heating variation
+    bias :
+        constant offset to all solar heating values
+    epoch :
+        reference date at which ``Ps`` values apply
+
+    Returns
+    -------
+
     """
     def __init__(self, model, node, pitch_comp, eclipse_comp=None,
                  P_pitches=None, Ps=None, dPs=None, var_func='exp',
@@ -211,8 +243,7 @@ class SolarHeat(PrecomputedHeatPower):
         self._epoch = value
 
     def dvals_post_hook(self):
-        """Override this method to adjust self._dvals after main computation.
-        """
+        """Override this method to adjust self._dvals after main computation."""
         pass
 
     def _compute_dvals(self):
@@ -298,21 +329,42 @@ class SolarHeatMulplicative(SolarHeat):
 class SolarHeatAcisCameraBody(SolarHeat):
     """Solar heating (pitch and SIM-Z dependent)
 
-    :param model: parent model
-    :param node: node which is coupled to solar heat
-    :param simz_comp: SimZ component
-    :param pitch_comp: solar Pitch component
-    :param eclipse_comp: Eclipse component (optional)
-    :param P_pitches: list of pitch values (default=[45, 65, 90, 130, 180])
-    :param Ps: list of solar heating values (default=[1.0, ...])
-    :param dPs: list of delta heating values (default=[0.0, ...])
-    :param var_func: variability function ('exp' | 'linear')
-    :param tau: variability timescale (days)
-    :param ampl: ampl of annual sinusoidal heating variation
-    :param bias: constant offset to all solar heating values
-    :param epoch: reference date at which ``Ps`` values apply
-    :param dh_heater_comp: detector housing heater status (True = On)
-    :param dh_heater_bias: bias power when DH heater is on
+    Parameters
+    ----------
+    model :
+        parent model
+    node :
+        node which is coupled to solar heat
+    simz_comp :
+        SimZ component
+    pitch_comp :
+        solar Pitch component
+    eclipse_comp :
+        Eclipse component (optional)
+    P_pitches :
+        list of pitch values (default=[45, 65, 90, 130, 180])
+    Ps :
+        list of solar heating values (default=[1.0, ...])
+    dPs :
+        list of delta heating values (default=[0.0, ...])
+    var_func :
+        variability function ('exp' | 'linear')
+    tau :
+        variability timescale (days)
+    ampl :
+        ampl of annual sinusoidal heating variation
+    bias :
+        constant offset to all solar heating values
+    epoch :
+        reference date at which ``Ps`` values apply
+    dh_heater_comp :
+        detector housing heater status (True = On)
+    dh_heater_bias :
+        bias power when DH heater is on
+
+    Returns
+    -------
+
     """
     def __init__(self, model, node, pitch_comp, eclipse_comp=None,
                  P_pitches=None, Ps=None, dPs=None, var_func='exp',
@@ -328,28 +380,47 @@ class SolarHeatAcisCameraBody(SolarHeat):
         self.add_par('dh_heater_bias', dh_heater_bias, min=-1.0, max=1.0)
 
     def dvals_post_hook(self):
-        """Apply a bias power offset when detector housing heater is on
-        """
+        """Apply a bias power offset when detector housing heater is on"""
         self._dvals[self.dh_heater_comp.dvals] += self.dh_heater_bias
 
 
 class SolarHeatHrc(SolarHeat):
     """Solar heating (pitch and SIM-Z dependent)
 
-    :param model: parent model
-    :param node: node which is coupled to solar heat
-    :param simz_comp: SimZ component
-    :param pitch_comp: solar Pitch component
-    :param eclipse_comp: Eclipse component (optional)
-    :param P_pitches: list of pitch values (default=[45, 65, 90, 130, 180])
-    :param Ps: list of solar heating values (default=[1.0, ...])
-    :param dPs: list of delta heating values (default=[0.0, ...])
-    :param var_func: variability function ('exp' | 'linear')
-    :param tau: variability timescale (days)
-    :param ampl: ampl of annual sinusoidal heating variation
-    :param bias: constant offset to all solar heating values
-    :param epoch: reference date at which ``Ps`` values apply
-    :param hrc_bias: solar heating bias when SIM-Z < 0 (HRC)
+    Parameters
+    ----------
+    model :
+        parent model
+    node :
+        node which is coupled to solar heat
+    simz_comp :
+        SimZ component
+    pitch_comp :
+        solar Pitch component
+    eclipse_comp :
+        Eclipse component (optional)
+    P_pitches :
+        list of pitch values (default=[45, 65, 90, 130, 180])
+    Ps :
+        list of solar heating values (default=[1.0, ...])
+    dPs :
+        list of delta heating values (default=[0.0, ...])
+    var_func :
+        variability function ('exp' | 'linear')
+    tau :
+        variability timescale (days)
+    ampl :
+        ampl of annual sinusoidal heating variation
+    bias :
+        constant offset to all solar heating values
+    epoch :
+        reference date at which ``Ps`` values apply
+    hrc_bias :
+        solar heating bias when SIM-Z < 0 (HRC)
+
+    Returns
+    -------
+
     """
     def __init__(self, model, node, simz_comp, pitch_comp, eclipse_comp=None,
                  P_pitches=None, Ps=None, dPs=None, var_func='exp',
@@ -362,8 +433,7 @@ class SolarHeatHrc(SolarHeat):
         self.add_par('hrc_bias', hrc_bias, min=-1.0, max=1.0)
 
     def dvals_post_hook(self):
-        """Apply a bias power offset when SIM-Z is at HRC-S or HRC-I.
-        """
+        """Apply a bias power offset when SIM-Z is at HRC-S or HRC-I."""
         if not hasattr(self, 'hrc_mask'):
             self.hrc_mask = self.simz_comp.dvals < 0
         self._dvals[self.hrc_mask] += self.hrc_bias
@@ -373,21 +443,42 @@ class SolarHeatHrcOpts(SolarHeat):
     """Solar heating (pitch and SIM-Z dependent, two parameters for
     HRC-I and HRC-S)
 
-    :param model: parent model
-    :param node: node which is coupled to solar heat
-    :param simz_comp: SimZ component
-    :param pitch_comp: solar Pitch component
-    :param eclipse_comp: Eclipse component (optional)
-    :param P_pitches: list of pitch values (default=[45, 65, 90, 130, 180])
-    :param Ps: list of solar heating values (default=[1.0, ...])
-    :param dPs: list of delta heating values (default=[0.0, ...])
-    :param var_func: variability function ('exp' | 'linear')
-    :param tau: variability timescale (days)
-    :param ampl: ampl of annual sinusoidal heating variation
-    :param bias: constant offset to all solar heating values
-    :param epoch: reference date at which ``Ps`` values apply
-    :param hrci_bias: solar heating bias when HRC-I is in the focal plane.
-    :param hrcs_bias: solar heating bias when HRC-S is in the focal plane.
+    Parameters
+    ----------
+    model :
+        parent model
+    node :
+        node which is coupled to solar heat
+    simz_comp :
+        SimZ component
+    pitch_comp :
+        solar Pitch component
+    eclipse_comp :
+        Eclipse component (optional)
+    P_pitches :
+        list of pitch values (default=[45, 65, 90, 130, 180])
+    Ps :
+        list of solar heating values (default=[1.0, ...])
+    dPs :
+        list of delta heating values (default=[0.0, ...])
+    var_func :
+        variability function ('exp' | 'linear')
+    tau :
+        variability timescale (days)
+    ampl :
+        ampl of annual sinusoidal heating variation
+    bias :
+        constant offset to all solar heating values
+    epoch :
+        reference date at which ``Ps`` values apply
+    hrci_bias :
+        solar heating bias when HRC-I is in the focal plane.
+    hrcs_bias :
+        solar heating bias when HRC-S is in the focal plane.
+
+    Returns
+    -------
+
     """
     def __init__(self, model, node, simz_comp, pitch_comp, eclipse_comp=None,
                  P_pitches=None, Ps=None, dPs=None, var_func='exp',
@@ -401,8 +492,7 @@ class SolarHeatHrcOpts(SolarHeat):
         self.add_par('hrcs_bias', hrcs_bias, min=-1.0, max=1.0)
 
     def dvals_post_hook(self):
-        """Apply a bias power offset when SIM-Z is at HRC-S or HRC-I.
-        """
+        """Apply a bias power offset when SIM-Z is at HRC-S or HRC-I."""
         if not hasattr(self, 'hrci_mask'):
             self.hrci_mask = (self.simz_comp.dvals < 0) & \
                              (self.simz_comp.dvals > -86147)
@@ -545,6 +635,13 @@ class EarthHeat(PrecomputedHeatPower):
     def get_cached(self):
         """Find a cached version of the Earth solid angle values from
         file if possible.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         dts = {}  # delta times for each matching file
         filenames = glob.glob('esa_cache/*.npz')
@@ -766,6 +863,13 @@ class AcisDpaPower(PrecomputedHeatPower):
     def get_dvals_tlm(self):
         """Model dvals is set to the telemetered power.  This is not actually
         used by the model, but is useful for diagnostics.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         try:
             dvals = self.model.fetch('dp_dpa_power')
@@ -834,6 +938,13 @@ class AcisDpaStatePower(PrecomputedHeatPower):
     """Heating from ACIS electronics (ACIS config dependent CCDs, FEPs etc).
     Use commanded states and assign an effective power for each "unique" power
     state.  See dpa/NOTES.power.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
     def __init__(self, model, node, mult=1.0,
                  fep_count=None, ccd_count=None,
@@ -899,6 +1010,13 @@ class AcisDpaStatePower(PrecomputedHeatPower):
     def get_dvals_tlm(self):
         """Model dvals is set to the telemetered power.  This is not actually
         used by the model, but is useful for diagnostics.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         try:
             dvals = self.model.fetch('dp_dpa_power')
@@ -911,6 +1029,13 @@ class AcisDpaStatePower(PrecomputedHeatPower):
         the current power parameters, then slice that with self.par_idxs to
         generate the predicted power (based on the parameter specifying state
         power) at each time step.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         power_parvals = np.array([par.val for par in self.power_pars])
         powers = power_parvals[self.par_idxs]
@@ -952,8 +1077,7 @@ class PropHeater(PrecomputedHeatPower):
         return 'prop_heat__{0}'.format(self.node)
 
     def get_dvals_tlm(self):
-        """Return an array of zeros => no activation of the heater.
-        """
+        """ """
         return np.zeros_like(self.model.times)
 
     def update(self):
@@ -976,8 +1100,7 @@ class PropHeater(PrecomputedHeatPower):
 
 
 class ThermostatHeater(ActiveHeatPower):
-    """Thermostat heater (no deadband): heat = P for T < T_set).
-    """
+    """Thermostat heater (no deadband): heat = P for T < T_set)."""
     def __init__(self, model, node, node_control=None, P=0.1, T_set=20.0):
         super(ThermostatHeater, self).__init__(model)
         self.node = self.model.get_comp(node)
@@ -991,8 +1114,7 @@ class ThermostatHeater(ActiveHeatPower):
         return 'thermostat_heat__{0}'.format(self.node)
 
     def get_dvals_tlm(self):
-        """Return an array of zeros => no activation of the heater.
-        """
+        """ """
         return np.zeros_like(self.model.times)
 
     def update(self):
@@ -1015,16 +1137,26 @@ class ThermostatHeater(ActiveHeatPower):
 
 
 class StepFunctionPower(PrecomputedHeatPower):
-    """
-    A class that applies a constant heat power shift only
+    """A class that applies a constant heat power shift only
     after a certain point in time.  The shift is 0.0 before
     ``time`` and ``P`` after ``time``.
 
-    :param model: parent model object
-    :param node: node name or object for which to apply shift
-    :param time: time of step function shift
-    :param P: size of shift in heat power (default=0.0)
-    :param id: str, identifier to allow multiple steps (default='')
+    Parameters
+    ----------
+    model :
+        parent model object
+    node :
+        node name or object for which to apply shift
+    time :
+        time of step function shift
+    P :
+        size of shift in heat power (default=0.0)
+    id :
+        str, identifier to allow multiple steps (default='')
+
+    Returns
+    -------
+
     """
     def __init__(self, model, node, time, P=0.0, id=''):
         super(StepFunctionPower, self).__init__(model)
@@ -1038,13 +1170,11 @@ class StepFunctionPower(PrecomputedHeatPower):
         return f'step_power{self.id}__{self.node}'
 
     def get_dvals_tlm(self):
-        """Return an array of zeros => no activation of the heater.
-        """
+        """ """
         return np.zeros_like(self.model.times)
 
     def update(self):
-        """Update the model prediction as a precomputed heat.
-        """
+        """Update the model prediction as a precomputed heat."""
         self.mvals = np.full_like(self.model.times, fill_value=self.P)
         idx0 = np.searchsorted(self.model.times, self.time)
         self.mvals[:idx0] = 0.0
@@ -1067,7 +1197,19 @@ class StepFunctionPower(PrecomputedHeatPower):
 
 @jit(nopython=True)
 def quat_to_transform_transpose(q):
-    """Return transpose of transform matrix for Quat q"""
+    """
+
+    Parameters
+    ----------
+    q :
+        
+
+    Returns
+    -------
+    type
+        
+
+    """
     x, y, z, w = q
     xx2 = 2 * x * x
     yy2 = 2 * y * y

--- a/xija/component/mask.py
+++ b/xija/component/mask.py
@@ -20,6 +20,13 @@ class Mask(ModelComponent):
       "lt": <
       "eq": ==
       "ne" !=
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
     def __init__(self, model, node, op, val, min_=-1e38, max_=1e38):
         ModelComponent.__init__(self, model)
@@ -69,6 +76,13 @@ class Mask(ModelComponent):
 class MaskBox(Mask):
     """Create object with a ``mask`` attribute corresponding to
       val0 < node.dvals < val1
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
     def __init__(self, model, node, val0, val1, min_=-1000, max_=1000):
         ModelComponent.__init__(self, model)

--- a/xija/gui_fit/app.py
+++ b/xija/gui_fit/app.py
@@ -789,23 +789,23 @@ class MainWindow(object):
     def open_console(self):
 
         def fit():
-            """
-            Perform a fit.
-            """
+            """Perform a fit."""
             self.fit_worker.start()
             self.fit_monitor()
 
         def freeze(params):
-            """
-            Freeze the parameter or parameters which
+            """Freeze the parameter or parameters which
             correspond to the given glob pattern.
 
             Parameters
             ----------
             params : string
-                The name of the parameter to freeze. 
+                The name of the parameter to freeze.
                 Multiple parameters can be specified using
                 a glob/regex pattern.
+
+            Returns
+            -------
 
             Examples
             --------
@@ -814,16 +814,18 @@ class MainWindow(object):
             self.parse_command("freeze {}".format(params))
 
         def thaw(params):
-            """
-            Thaw the parameter or parameters which
+            """Thaw the parameter or parameters which
             correspond to the given glob pattern.
 
             Parameters
             ----------
             params : string
-                The name of the parameter to thaw. 
+                The name of the parameter to thaw.
                 Multiple parameters can be specified using
                 a glob/regex pattern.
+
+            Returns
+            -------
 
             Examples
             --------
@@ -832,8 +834,7 @@ class MainWindow(object):
             self.parse_command("thaw {}".format(params))
 
         def ignore(tstart, tstop):
-            """
-            Ignore specified time ranges when performing a fit.
+            """Ignore specified time ranges when performing a fit.
 
             Parameters
             ----------
@@ -846,12 +847,15 @@ class MainWindow(object):
                 If None, this will default to the end of the
                 imported data range.
 
+            Returns
+            -------
+
             Examples
             --------
             >>> # When only the year and DOY are included,
             >>> # assumed time is 12:00:00
             >>> ignore("2019:100:09:10:12", "2019:200")
-
+            
             >>> ignore(None, "2019:056:17:15:10")
             """
             if tstart is None:
@@ -861,10 +865,16 @@ class MainWindow(object):
             self.parse_command("ignore {} {}".format(tstart, tstop))
 
         def notice():
-            """
-            Remove all time masks which were set by the
+            """Remove all time masks which were set by the
             *ignore* command. Note: this does not remove
             "bad times".
+
+            Parameters
+            ----------
+
+            Returns
+            -------
+
             """
             self.parse_command("notice")
 
@@ -983,6 +993,13 @@ class MainWindow(object):
         possibility for other commands later) and the subsequent args are
         space-delimited parameter globs using the UNIX file-globbing syntax.
         This then sets the corresponding params_table checkbuttons.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         widget = self.cbp.command_entry
         command = widget.text().strip()

--- a/xija/gui_fit/fitter.py
+++ b/xija/gui_fit/fitter.py
@@ -93,6 +93,15 @@ class FitWorker(object):
 
     def start(self, widget=None):
         """Start a Sherpa fit process as a spawned (non-blocking) process.
+
+        Parameters
+        ----------
+        widget :
+             (Default value = None)
+
+        Returns
+        -------
+
         """
         self.fit_process = mp.Process(target=self.fit)
         self.fit_process.start()
@@ -101,6 +110,15 @@ class FitWorker(object):
     def terminate(self, widget=None):
         """Terminate a Sherpa fit process in a controlled way by sending a
         message.  Get the final parameter values if possible.
+
+        Parameters
+        ----------
+        widget :
+             (Default value = None)
+
+        Returns
+        -------
+
         """
         if hasattr(self, "fit_process"):
             # Only do this if we had started a fit to begin with

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -11,11 +11,19 @@ import matplotlib.dates as mdates
 
 
 def digitize_data(Ttelem, nbins=50):
-    """ Digitize telemetry.
+    """Digitize telemetry.
 
-    :param Ttelem: telemetry values
-    :param nbins: number of bins
-    :returns: coordinates for error quantile line
+    Parameters
+    ----------
+    Ttelem :
+        telemetry values
+    nbins :
+        number of bins (Default value = 50)
+
+    Returns
+    -------
+    type
+        coordinates for error quantile line
 
     """
 
@@ -30,10 +38,19 @@ def digitize_data(Ttelem, nbins=50):
 
 
 def calcquantiles(errors):
-    """ Calculate the error quantiles.
+    """Calculate the error quantiles.
 
-    :param error: model errors (telemetry - model)
-    :returns: datastructure that includes errors (input) and quantile values
+    Parameters
+    ----------
+    error :
+        model errors (telemetry - model)
+    errors :
+        
+
+    Returns
+    -------
+    type
+        datastructure that includes errors (input) and quantile values
 
     """
 
@@ -51,13 +68,21 @@ def calcquantiles(errors):
 
 
 def calcquantstats(Ttelem, error):
-    """ Calculate error quantiles for individual telemetry temperatures (each count individually).
+    """Calculate error quantiles for individual telemetry temperatures (each count individually).
 
-    :param Ttelem: telemetry values
-    :param error: model error (telemetry - model)
-    :returns: coordinates for error quantile line
+    Parameters
+    ----------
+    Ttelem :
+        telemetry values
+    error :
+        model error (telemetry - model)
 
-    This is used for the telemetry vs. error plot (axis 3).
+    Returns
+    -------
+    type
+        coordinates for error quantile line
+        
+        This is used for the telemetry vs. error plot (axis 3).
 
     """
 
@@ -76,14 +101,22 @@ def calcquantstats(Ttelem, error):
 
 
 def getQuantPlotPoints(quantstats, quantile):
-    """ Calculate the error quantile line coordinates for the data in each telemetry count value.
+    """Calculate the error quantile line coordinates for the data in each telemetry count value.
 
-    :param quantstats: output from calcquantstats()
-    :param quantile: quantile (string - e.g. "q01"), used as a key into quantstats datastructure
-    :returns: coordinates for error quantile line
+    Parameters
+    ----------
+    quantstats :
+        output from calcquantstats()
+    quantile :
+        quantile (string - e.g. "q01"), used as a key into quantstats datastructure
 
-    This is used to calculate the quantile lines plotted on the telemetry vs. error plot (axis 3)
-    enclosing the data (i.e. the 1 and 99 percentile lines).
+    Returns
+    -------
+    type
+        coordinates for error quantile line
+        
+        This is used to calculate the quantile lines plotted on the telemetry vs. error plot (axis 3)
+        enclosing the data (i.e. the 1 and 99 percentile lines).
 
     """
 
@@ -106,8 +139,16 @@ def get_radzones(model):
 
 
 def clearLayout(layout):
-    """
-    From http://stackoverflow.com/questions/9374063/pyqt4-remove-widgets-and-layout-as-well
+    """From http://stackoverflow.com/questions/9374063/pyqt4-remove-widgets-and-layout-as-well
+
+    Parameters
+    ----------
+    layout :
+        
+
+    Returns
+    -------
+
     """
     if layout is not None:
         while layout.count():

--- a/xija/gui_fit/utils.py
+++ b/xija/gui_fit/utils.py
@@ -36,15 +36,21 @@ def start_in_process_kernel():
 
 
 def in_process_console(console_class=RichJupyterWidget, **kwargs):
-    """
-    Create a console widget, connected to an in-process Kernel
-
+    """Create a console widget, connected to an in-process Kernel
+    
     Keyword arguments will be added to the namespace of the shell.
 
     Parameters
     ----------
-    console_class : `type`
-        The class of the console widget to create
+    console_class :
+         (Default value = RichJupyterWidget)
+    **kwargs :
+        
+
+    Returns
+    -------
+
+    
     """
 
     global kernel_manager, kernel_client

--- a/xija/model.py
+++ b/xija/model.py
@@ -61,9 +61,9 @@ class FetchError(Exception):
 class XijaModel(object):
     """Xija model class to encapsulate all ModelComponents and provide the
     infrastructure to define and evaluate models.
-
+    
     The parameters ``name``, ``start``, and ``stop`` are determined as follows:
-
+    
     - If a model specification is provided then that sets the default values
       for keywords that are not supplied to the class init call.
     - ``evolve_method = 1`` uses the original ODE solver which treats every
@@ -74,16 +74,31 @@ class XijaModel(object):
       ``stop = NOW - 30 days``, ``dt = 328 secs``, ``evolve_method = 1``,
       ``rk4 = 0``
 
-    :param name: model name
-    :param start: model start time (any DateTime format)
-    :param stop: model stop time (any DateTime format)
-    :param dt: delta time step (default=328 sec)
-    :param model_spec: model specification (None | filename | dict)
-    :param cmd_states: commanded states input (None | structured array)
-    :param evolve_method: choose method to evolve ODE (None | 1 or 2, default 1)
-    :param rk4: use 4th-order Runge-Kutta to evolve ODE, only works with
-           evolve_method == 2 (None | 0 or 1, default 0)
-    :param limits: dict of limit values (None | dict)
+    Parameters
+    ----------
+    name :
+        model name
+    start :
+        model start time (any DateTime format)
+    stop :
+        model stop time (any DateTime format)
+    dt :
+        delta time step (default=328 sec)
+    model_spec :
+        model specification (None | filename | dict)
+    cmd_states :
+        commanded states input (None | structured array)
+    evolve_method :
+        choose method to evolve ODE (None | 1 or 2, default 1)
+    rk4 :
+        use 4th-order Runge-Kutta to evolve ODE, only works with
+        evolve_method == 2 (None | 0 or 1, default 0)
+    limits :
+        dict of limit values (None | dict)
+
+    Returns
+    -------
+
     """
     def __init__(self, name=None, start=None, stop=None, dt=None,
                  model_spec=None, cmd_states=None, evolve_method=None,
@@ -151,10 +166,18 @@ class XijaModel(object):
         self.cmd_states = cmd_states
 
     def _get_allowed_timestep(self, dt):
-        """
-        This method ensures that only certain timesteps are chosen,
+        """This method ensures that only certain timesteps are chosen,
         which are integer multiples of 8.2 and where 328.0/dt is an
         integer.
+
+        Parameters
+        ----------
+        dt :
+            
+
+        Returns
+        -------
+
         """
         if dt > DEFAULT_DT:
             logger.warning("dt = %g s greater than upper "
@@ -186,6 +209,15 @@ class XijaModel(object):
         """Inherit parameter values from any like-named parameters within the
         inherit_spec model specification.  This is useful for making a new
         variation of an existing model.
+
+        Parameters
+        ----------
+        inherit_spec :
+            
+
+        Returns
+        -------
+
         """
         try:
             inherit_spec = json.load(open(inherit_spec, 'r'))
@@ -203,9 +235,21 @@ class XijaModel(object):
                 par.fmt = inherit_pars[par.full_name]['fmt']
 
     def _eng_match_times(self, start, stop):
-        """Return an array of times between ``start`` and ``stop`` at ``dt``
-        sec intervals.  The times are roughly aligned (within 1 sec) to the
-        timestamps in the '5min' (328 sec) Ska eng archive data.
+        """
+
+        Parameters
+        ----------
+        start :
+            
+        stop :
+            
+
+        Returns
+        -------
+        type
+            sec intervals.  The times are roughly aligned (within 1 sec) to the
+            timestamps in the '5min' (328 sec) Ska eng archive data.
+
         """
         time0 = 410270764.0
         i0 = int((DateTime(start).secs - time0) / self.dt) + 1
@@ -225,7 +269,14 @@ class XijaModel(object):
     def _set_cmd_states(self, states):
         """Set the states that define component data inputs.
 
-        :param states: numpy structured array
+        Parameters
+        ----------
+        states :
+            numpy structured array
+
+        Returns
+        -------
+
         """
         if states is not None:
             if (states[0]['tstart'] >= self.times[0] or
@@ -242,7 +293,21 @@ class XijaModel(object):
     """test cmdstats"""
 
     def fetch(self, msid, attr='vals', method='linear'):
-        """Get data from the Chandra engineering archive."""
+        """Get data from the Chandra engineering archive.
+
+        Parameters
+        ----------
+        msid :
+            
+        attr :
+             (Default value = 'vals')
+        method :
+             (Default value = 'linear')
+
+        Returns
+        -------
+
+        """
         tpad = DEFAULT_DT*5.0
         datestart = DateTime(self.tstart - tpad).date
         datestop = DateTime(self.tstop + tpad).date
@@ -264,12 +329,25 @@ class XijaModel(object):
     def interpolate_data(self, data, times, comp=None):
         """Interpolate supplied ``data`` values at the model times using
         nearest-neighbor or state value interpolation.
-
+        
         The ``times`` arg can be either a 1-d or 2-d ndarray.  If 1-d,
         then ``data`` is interpreted as a set of values at the specified
         ``times``.  If 2-d then ``data`` is interpreted as a set of binned
         state values with ``tstarts = times[0, :]`` and
         ``tstops = times[1, :]``.
+
+        Parameters
+        ----------
+        data :
+            
+        times :
+            
+        comp :
+             (Default value = None)
+
+        Returns
+        -------
+
         """
         if times is None:
             if len(data) != self.n_times:
@@ -298,7 +376,21 @@ class XijaModel(object):
         return vals
 
     def add(self, ComponentClass, *args, **kwargs):
-        """Add a new component to the model"""
+        """Add a new component to the model
+
+        Parameters
+        ----------
+        ComponentClass :
+            
+        *args :
+            
+        **kwargs :
+            
+
+        Returns
+        -------
+
+        """
         comp = ComponentClass(self, *args, **kwargs)
         # Store args and kwargs used to initialize object for later object
         # storage and re-creation
@@ -315,13 +407,31 @@ class XijaModel(object):
 
     def get_comp(self, name):
         """Get a model component.  Works with either a string or a component
-        object"""
+        object
+
+        Parameters
+        ----------
+        name :
+            
+
+        Returns
+        -------
+
+        """
         return None if name is None else self.comp[str(name)]
 
     @property
     def model_spec(self):
         """Generate a full model specification data structure for this
-        model"""
+        model
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
+        """
         model_spec = dict(name=self.name,
                           comps=[],
                           dt=self.dt,
@@ -356,6 +466,15 @@ class XijaModel(object):
         just dvals (TelemData), others have both (Node, AcisDpaPower).
         Everything is guaranteed to be time synced, so write a single time
         column.
+
+        Parameters
+        ----------
+        filename :
+            
+
+        Returns
+        -------
+
         """
         colvals = OrderedDict(time=self.times)
         for comp in self.comps:
@@ -368,13 +487,21 @@ class XijaModel(object):
 
     def write(self, filename, model_spec=None):
         """Write the model specification as JSON or Python to a file.
-
+        
         If the file name ends with ".py" then the output will the Python
         code to create the model (using ``get_model_code()``), otherwise
         the JSON model specification will be written.
 
-        :param filename: output filename
-        :param model_spec: model spec structure (optional)
+        Parameters
+        ----------
+        filename :
+            output filename
+        model_spec :
+            model spec structure (optional) (Default value = None)
+
+        Returns
+        -------
+
         """
         if model_spec is None:
             model_spec = self.model_spec
@@ -387,11 +514,18 @@ class XijaModel(object):
 
     def get_model_code(self):
         """Return Python code that will create the current model.
-
+        
         This is useful during model development as a way to derive from and
         modify existing models while retaining good parameter values.
 
-        :returns: string of Python code
+        Parameters
+        ----------
+
+        Returns
+        -------
+        type
+            string of Python code
+
         """
         out = StringIO()
         ms = self.model_spec
@@ -438,13 +572,23 @@ class XijaModel(object):
         return out.getvalue()
 
     def _get_parvals(self):
-        """Return a (read-only) tuple of parameter values."""
+        """ """
         return tuple(par.val for par in self.pars)
 
     def _set_parvals(self, vals):
         """Set the full list of parameter values.  No provision is made for
         setting individual elements or slicing (use self.pars directly in this
-        case)."""
+        case).
+
+        Parameters
+        ----------
+        vals :
+            
+
+        Returns
+        -------
+
+        """
         if len(vals) != len(self.pars):
             raise ValueError('Length mismatch setting parvals {} vs {}'.format(
                     len(self.pars), len(vals)))
@@ -455,12 +599,20 @@ class XijaModel(object):
 
     @property
     def parnames(self):
-        """Return a tuple of all model parameter names"""
+        """ """
         return tuple(par.full_name for par in self.pars)
 
     def make(self):
         """Call self.make_mvals and self.make_tmal to prepare for model evaluation
-        once all model components have been added."""
+        once all model components have been added.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
+        """
         self.make_mvals()
         self.make_tmal()
 
@@ -471,6 +623,13 @@ class XijaModel(object):
         relevant data values (e.g. node temps, time-dependent power,
         external temperatures, etc).  In the model calculation some
         rows will be overwritten with predictions.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         # Select components with data values, and from those select ones that
         # get predicted and those that do not get predicted
@@ -491,8 +650,16 @@ class XijaModel(object):
         self.cvals = self.mvals[:, 0::2]
 
     def make_tmal(self):
-        """ Make the TMAL "code" using components that generate TMAL
-        statements"""
+        """Make the TMAL "code" using components that generate TMAL
+        statements
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
+        """
         for comp in self.comps:
             comp.update()
         tmal_comps = [x for x in self.comps if hasattr(x, 'tmal_ints')]
@@ -535,12 +702,22 @@ class XijaModel(object):
         return fit_stat
 
     def calc_staterror(self, data):
-        """Calculate model fit statistic error (dummy array for Sherpa use)"""
+        """Calculate model fit statistic error (dummy array for Sherpa use)
+
+        Parameters
+        ----------
+        data :
+            
+
+        Returns
+        -------
+
+        """
         return np.ones_like(data)
 
     @property
     def date_range(self):
-        """Return formatted date range string"""
+        """ """
         return '%s_%s' % (DateTime(self.tstart).greta[:7],
                           DateTime(self.tstop).greta[:7])
 
@@ -549,6 +726,13 @@ class XijaModel(object):
         """Lazy-load the "core_1" ctypes shared object libary that does the
         low-level model calculation via the C "calc_model_1" routine.  Only
         load once by setting/returning a class attribute.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         if not hasattr(XijaModel, '_core_1'):
             loader_path = os.path.abspath(os.path.dirname(__file__))
@@ -569,6 +753,13 @@ class XijaModel(object):
         """Lazy-load the "core_2" ctypes shared object libary that does the
         low-level model calculation via the C "calc_model_2" routine.  Only
         load once by setting/returning a class attribute.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         if not hasattr(XijaModel, '_core_2'):
             loader_path = os.path.abspath(os.path.dirname(__file__))

--- a/xija/tests/test_models.py
+++ b/xija/tests/test_models.py
@@ -46,10 +46,16 @@ def test_dpa_real():
 
 
 def test_pitch_clip():
-    """
-    Pitch in this time range goes from 48.62 to 158.41.  dpa_clip.json
+    """Pitch in this time range goes from 48.62 to 158.41.  dpa_clip.json
     has been modified so the solarheat pitch range is from 55 .. 153.
     Make sure the model still runs with no interpolation error.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
     mdl = ThermalModel('dpa', start='2012:001:12:00:00', stop='2012:007:12:00:00',
                        model_spec=abs_path('dpa_clip.json'))
@@ -60,13 +66,19 @@ def test_pitch_clip():
 
 
 def test_pitch_range_clip():
-    """
-    Pitch in this time range goes from approximately 48.5 to 175.0 degrees.
+    """Pitch in this time range goes from approximately 48.5 to 175.0 degrees.
     pftank2t.json is used as a placeholder to load a new thermal model, and
     should be able to be replaced with any other model. Make sure the pitch
     range stored in the model object does not get clipped to a narrower range.
     Make sure the pitch range stored does not include values outside of the 45
     to 180 degree range.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
     mdl = ThermalModel('tank', start='2019:120:12:00:00', stop='2019:122:12:00:00',
                        model_spec=abs_path('pftank2t.json'))


### PR DESCRIPTION
## Description

This migrates all the docstrings for xija to use the `numpydoc` style / extension.  The actual docstring migration was done fully automatically with the statement below after doing a --user local install of `pyment` with pip.

```
~/.local/bin/pyment --output numpydoc --write --convert xija
```

There is room for improvement in the actual values of parameters etc., but this PR is just about migration.

## Testing

- [N/A] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

### Functional testing

Built HTML documentation with no warnings. The API docs appear as expected.
