### PR TITLE
Add timeout error catch that occurs on linux

### DIFF
--- a/xija/get_model_spec.py
+++ b/xija/get_model_spec.py
@@ -206,7 +206,7 @@ def get_github_version(url: str = CHANDRA_MODELS_URL,
     """
     try:
         req = requests.get(url, timeout=timeout)
-    except requests.ConnectTimeout:
+    except (requests.ConnectTimeout, requests.ReadTimeout):
         return None
 
     if req.status_code != requests.codes.ok:


### PR DESCRIPTION
## Description

The exception that occurs for a timeout on linux is apparently different from that on Mac. 

## Testing

- [x] Passes unit tests on MacOS, linux.
- [N/A] Functional testing

Fixes: dashboard test failure for xija