### PR TITLE
Add MSIDStatePower component

### DIFF
--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -1065,6 +1065,69 @@ class StepFunctionPower(PrecomputedHeatPower):
             ax.set_ylabel('Power')
 
 
+class MsidStatePower(PrecomputedHeatPower):
+    """
+    A class that applies a constant heat power shift only when the state of an
+    MSID, ``state_msid``, matches a specified value, ``state_val``.  The shift
+    is ``P`` when the ``state_val`` for ``state_msid`` is matched, otherwise it
+    is 0.0.
+
+    :param model: parent model object
+    :param node: node name or object for which to apply shift
+    :param state_msid: state MSID name
+    :param state_val: value of ``state_msid`` to be matched
+    :param P: size of shift in heat power (default=0.0)
+
+    The name of this component is constructed by concatenating the state msid name
+    and the state msid value with an underscore. For example, if the ``MsidStatePower``
+    component defines a power value for when the COSSRBX values match the string,
+    "ON ", the name of this component is ``cossrbx_on``.
+
+    The ``dvals`` data stored for this component are a boolean type. To initialize
+    this component, one would use the following syntax:
+        model.comp['cossrbx_on'].set_data(True)
+
+    """
+    def __init__(self, model, node, state_msid, state_val, P=0.0):
+        super(MsidStatePower, self).__init__(model)
+        self.node = self.model.get_comp(node)
+        self.state_msid = str(state_msid).lower()
+        self.state_val = state_val
+        self.state_val_str = str(state_val).lower().strip()
+        self.n_mvals = 1
+        self.add_par('P', P, min=-10.0, max=10.0)
+
+    def __str__(self):
+        return f'{self.state_msid}_{self.state_val_str}'
+
+    def get_dvals_tlm(self):
+        """
+        Return an array of power values where the power is ``P`` when the
+        ``state_val`` for ``state_msid`` is matched, otherwise it is 0.0.
+        """
+        dvals = self.model.fetch(self.state_msid, 'vals', 'nearest') == self.state_val
+        return dvals
+
+    def update(self):
+        self.mvals = np.zeros_like(self.model.times)
+        self.mvals[self.dvals] = self.P
+        self.tmal_ints = (tmal.OPCODES['precomputed_heat'],
+                          self.node.mvals_i,  # dy1/dt index
+                          self.mvals_i,
+                          )
+        self.tmal_floats = ()
+
+    def plot_data__time(self, fig, ax):
+        lines = ax.get_lines()
+        if lines:
+            lines[0].set_data(self.model_plotdate, self.mvals)
+        else:
+            plot_cxctime(self.model.times, self.mvals, '#386cb0', fig=fig, ax=ax)
+            ax.grid()
+            ax.set_title(f'{self.name}: data (blue)')
+            ax.set_ylabel('MSID State Power')
+
+
 @jit(nopython=True)
 def quat_to_transform_transpose(q):
     """Return transpose of transform matrix for Quat q"""

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -1119,13 +1119,11 @@ class MsidStatePower(PrecomputedHeatPower):
 
     def plot_data__time(self, fig, ax):
         lines = ax.get_lines()
-        if lines:
-            lines[0].set_data(self.model_plotdate, self.mvals)
-        else:
-            plot_cxctime(self.model.times, self.mvals, '#386cb0', fig=fig, ax=ax)
+        if not lines:
+            plot_cxctime(self.model.times, self.dvals, '#386cb0', fig=fig, ax=ax)
             ax.grid()
-            ax.set_title(f'{self.name}: data (blue)')
-            ax.set_ylabel('MSID State Power')
+            ax.set_title(f'{self.name}: state match dvals (blue)')
+            ax.set_ylabel(f'{self.state_msid.upper()} == {repr(self.state_val)}')
 
 
 @jit(nopython=True)


### PR DESCRIPTION
This update adds the ability to apply a heat power shift when a state msid matches a specified value.

## Description

In fitting a new fuel tank model, I found that there is a dependency on the SSR-B state, which can’t be accounted for in Xija without a new heat component. Since I anticipate using this type of state-based heat input for other models in other locations, I built a new flexible Xija heat component that can be defined to use a user-selected msid and state pair.

Here is an example that covers the key information one needs to use this update in the JSON model definition:

In the “comps” section:
```
      {
            "class_name": "MsidStatePower",
            "init_args": [],
            "init_kwargs": {
                "P": 0.5,
                "node": "pf0tank2t",
                "state_msid": "COSSRBX",
                "state_val": "ON "
            },
            "name": "cossrbx_on"
        }
```
In the “pars” section:
```
        {
            "comp_name": "cossrbx_on__pf0tank2t",
            "fmt": "{:.4g}",
            "frozen": false,
            "full_name": "cossrbx_on__pf0tank2t__P",
            "max": 2.0,
            "min": -2.0,
            "name": "P",
            "val": 0.004859426906919793
        }
```

Here is a link to a model that uses this new component: https://github.com/sot/chandra_models/blob/abaa609805431d72da9d4bc949ed5a5c7feb75d4/chandra_models/xija/pftank2t/pftank2t_spec.json


Doc string for this method copied here for convenience:
```
    A class that applies a constant heat power shift only when the state of an
     MSID, ``state_msid``, matches a specified value, ``state_val``.  The shift
     is ``P`` when the ``state_val`` for ``state_msid`` is matched, otherwise it
     is 0.0.

     :param model: parent model object
     :param node: node name or object for which to apply shift
     :param state_msid: state MSID name
     :param state_val: value of ``state_msid`` to be matched
     :param P: size of shift in heat power (default=0.0)

     The name of this component is constructed by concatenating the state msid name
     and the state msid value with an underscore. For example, if the ``MsidStatePower``
     component defines a power value for when the COSSRBX values match the string,
     "ON ", the name of this component is ``cossrbx_on``.

     The ``dvals`` data stored for this component are a boolean type. To initialize
     this component, one would use the following syntax:
         model.comp['cossrbx_on'].set_data(True)
```
## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing

