### PR TITLE
Add a Delay model component

### DIFF
--- a/examples/delay/4hfspat_delay.json
+++ b/examples/delay/4hfspat_delay.json
@@ -1,0 +1,340 @@
+{
+    "bad_times": [],
+    "comps": [
+        {
+            "class_name": "Node",
+            "init_args": [
+                "4hfspat"
+            ],
+            "init_kwargs": {},
+            "name": "4hfspat"
+        },
+        {
+            "class_name": "Delay",
+            "init_args": [
+                "4hfspat"
+            ],
+            "init_kwargs": {
+                "delay": 0
+            },
+            "name": "delay__4hfspat"
+        },
+        {
+            "class_name": "Pitch",
+            "init_args": [],
+            "init_kwargs": {},
+            "name": "pitch"
+        },
+        {
+            "class_name": "Eclipse",
+            "init_args": [],
+            "init_kwargs": {},
+            "name": "eclipse"
+        },
+        {
+            "class_name": "SolarHeat",
+            "init_args": [],
+            "init_kwargs": {
+                "P_pitches": [
+                    45,
+                    70,
+                    90,
+                    115,
+                    140,
+                    160,
+                    180
+                ],
+                "Ps": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                "ampl": 0.0,
+                "eclipse_comp": "eclipse",
+                "epoch": "2021:001",
+                "node": "4hfspat",
+                "pitch_comp": "pitch"
+            },
+            "name": "solarheat__4hfspat"
+        },
+        {
+            "class_name": "HeatSink",
+            "init_args": [],
+            "init_kwargs": {
+                "T": -16.0,
+                "node": "4hfspat",
+                "tau": 30.0
+            },
+            "name": "heatsink__4hfspat"
+        },
+        {
+            "class_name": "StepFunctionPower",
+            "init_args": [],
+            "init_kwargs": {
+                "P": 0.07,
+                "id": "_2iru",
+                "node": "4hfspat",
+                "time": "2018:283:14:00:00"
+            },
+            "name": "step_power_2iru__4hfspat"
+        },
+        {
+            "class_name": "StepFunctionPower",
+            "init_args": [],
+            "init_kwargs": {
+                "P": -0.07,
+                "id": "_1iru",
+                "node": "4hfspat",
+                "time": "2020:213:04:25:12"
+            },
+            "name": "step_power_1iru__4hfspat"
+        }
+    ],
+    "datestart": "2017:301:00:01:50.816",
+    "datestop": "2021:039:23:53:18.816",
+    "dt": 328.0,
+    "evolve_method": 1,
+    "gui_config": {
+        "filename": "/Users/aldcroft/git/xija/4hfspat_delay.json",
+        "plot_names": [
+            "4hfspat data__time",
+            "solarheat__4hfspat solar_heat__pitch"
+        ],
+        "set_data_vals": {},
+        "size": [
+            1556,
+            800
+        ]
+    },
+    "limits": {},
+    "mval_names": [],
+    "name": "4hfspat",
+    "pars": [
+        {
+            "comp_name": "delay__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "delay__4hfspat__delay",
+            "max": 40,
+            "min": -40,
+            "name": "delay",
+            "val": 13.499999999999996
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__4hfspat__P_45",
+            "max": 10.0,
+            "min": -10.0,
+            "name": "P_45",
+            "val": 0.17233635027684308
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__4hfspat__P_70",
+            "max": 10.0,
+            "min": -10.0,
+            "name": "P_70",
+            "val": 0.23062326409902983
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__4hfspat__P_90",
+            "max": 10.0,
+            "min": -10.0,
+            "name": "P_90",
+            "val": 0.24228417253874154
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__4hfspat__P_115",
+            "max": 10.0,
+            "min": -10.0,
+            "name": "P_115",
+            "val": 0.23496721731515693
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__4hfspat__P_140",
+            "max": 10.0,
+            "min": -10.0,
+            "name": "P_140",
+            "val": 0.1984902466681594
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__4hfspat__P_160",
+            "max": 10.0,
+            "min": -10.0,
+            "name": "P_160",
+            "val": 0.155
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__4hfspat__P_180",
+            "max": 10.0,
+            "min": -10.0,
+            "name": "P_180",
+            "val": 0.08412094201747869
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__4hfspat__dP_45",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_45",
+            "val": 0.020381767596966242
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__4hfspat__dP_70",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_70",
+            "val": 0.02
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__4hfspat__dP_90",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_90",
+            "val": 0.020901514422723914
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__4hfspat__dP_115",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_115",
+            "val": 0.018624230162238496
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__4hfspat__dP_140",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_140",
+            "val": 0.01915172892676302
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__4hfspat__dP_160",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_160",
+            "val": 0.02154387208115857
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__4hfspat__dP_180",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_180",
+            "val": 0.02
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__4hfspat__tau",
+            "max": 3000.0,
+            "min": 1000.0,
+            "name": "tau",
+            "val": 1732.0
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__4hfspat__ampl",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "ampl",
+            "val": 0.00439453125
+        },
+        {
+            "comp_name": "solarheat__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__4hfspat__bias",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "bias",
+            "val": 0.0
+        },
+        {
+            "comp_name": "heatsink__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "heatsink__4hfspat__T",
+            "max": 100.0,
+            "min": -100.0,
+            "name": "T",
+            "val": -17.38862456311714
+        },
+        {
+            "comp_name": "heatsink__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "heatsink__4hfspat__tau",
+            "max": 300.0,
+            "min": 2.0,
+            "name": "tau",
+            "val": 224.16634713698585
+        },
+        {
+            "comp_name": "step_power_2iru__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "step_power_2iru__4hfspat__P",
+            "max": 10.0,
+            "min": -10.0,
+            "name": "P",
+            "val": 0.011488201458560068
+        },
+        {
+            "comp_name": "step_power_1iru__4hfspat",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "step_power_1iru__4hfspat__P",
+            "max": 10.0,
+            "min": -10.0,
+            "name": "P",
+            "val": -0.010011660309755826
+        }
+    ],
+    "rk4": 0,
+    "tlm_code": null
+}

--- a/examples/delay/4hfspat_delay.py
+++ b/examples/delay/4hfspat_delay.py
@@ -1,0 +1,121 @@
+import sys
+import xija
+
+model = xija.XijaModel('4hfspat', start='2017:301:00:01:50.816', stop='2021:039:23:53:18.816', dt=328.0,
+evolve_method=1, rk4=0)
+
+model.add(xija.Node,
+          '4hfspat',
+         )
+model.add(xija.Delay,
+          '4hfspat',
+          delay=0,
+         )
+model.add(xija.Pitch,
+         )
+model.add(xija.Eclipse,
+         )
+model.add(xija.SolarHeat,
+          P_pitches=[45, 70, 90, 115, 140, 160, 180],
+          Ps=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+          ampl=0.0,
+          eclipse_comp='eclipse',
+          epoch='2021:001',
+          node='4hfspat',
+          pitch_comp='pitch',
+         )
+model.add(xija.HeatSink,
+          T=-16.0,
+          node='4hfspat',
+          tau=30.0,
+         )
+model.add(xija.StepFunctionPower,
+          P=0.07,
+          id='_2iru',
+          node='4hfspat',
+          time='2018:283:14:00:00',
+         )
+model.add(xija.StepFunctionPower,
+          P=-0.07,
+          id='_1iru',
+          node='4hfspat',
+          time='2020:213:04:25:12',
+         )
+# Set delay__4hfspat component parameters
+comp = model.get_comp('delay__4hfspat')
+
+par = comp.get_par('delay')
+par.update(dict(val=13.499999999999996, min=-40, max=40, fmt='{:.4g}', frozen=True))
+
+# Set solarheat__4hfspat component parameters
+comp = model.get_comp('solarheat__4hfspat')
+
+par = comp.get_par('P_45')
+par.update(dict(val=0.17233635027684308, min=-10.0, max=10.0, fmt='{:.4g}', frozen=True))
+
+par = comp.get_par('P_70')
+par.update(dict(val=0.23062326409902983, min=-10.0, max=10.0, fmt='{:.4g}', frozen=True))
+
+par = comp.get_par('P_90')
+par.update(dict(val=0.24228417253874154, min=-10.0, max=10.0, fmt='{:.4g}', frozen=True))
+
+par = comp.get_par('P_115')
+par.update(dict(val=0.23567973954542965, min=-10.0, max=10.0, fmt='{:.4g}', frozen=True))
+
+par = comp.get_par('P_140')
+par.update(dict(val=0.20035097429726695, min=-10.0, max=10.0, fmt='{:.4g}', frozen=True))
+
+par = comp.get_par('P_180')
+par.update(dict(val=0.09145374642612553, min=-10.0, max=10.0, fmt='{:.4g}', frozen=True))
+
+par = comp.get_par('dP_45')
+par.update(dict(val=0.020381767596966242, min=-1.0, max=1.0, fmt='{:.4g}', frozen=False))
+
+par = comp.get_par('dP_70')
+par.update(dict(val=0.014634511459946929, min=-1.0, max=1.0, fmt='{:.4g}', frozen=False))
+
+par = comp.get_par('dP_90')
+par.update(dict(val=0.020901514422723914, min=-1.0, max=1.0, fmt='{:.4g}', frozen=False))
+
+par = comp.get_par('dP_115')
+par.update(dict(val=0.01900222576906281, min=-1.0, max=1.0, fmt='{:.4g}', frozen=False))
+
+par = comp.get_par('dP_140')
+par.update(dict(val=0.01961773304332897, min=-1.0, max=1.0, fmt='{:.4g}', frozen=False))
+
+par = comp.get_par('dP_180')
+par.update(dict(val=0.025397352169416534, min=-1.0, max=1.0, fmt='{:.4g}', frozen=False))
+
+par = comp.get_par('tau')
+par.update(dict(val=1732.0, min=1000.0, max=3000.0, fmt='{:.4g}', frozen=True))
+
+par = comp.get_par('ampl')
+par.update(dict(val=0.00439453125, min=-1.0, max=1.0, fmt='{:.4g}', frozen=True))
+
+par = comp.get_par('bias')
+par.update(dict(val=0.0, min=-1.0, max=1.0, fmt='{:.4g}', frozen=True))
+
+# Set heatsink__4hfspat component parameters
+comp = model.get_comp('heatsink__4hfspat')
+
+par = comp.get_par('T')
+par.update(dict(val=-17.38862456311714, min=-100.0, max=100.0, fmt='{:.4g}', frozen=True))
+
+par = comp.get_par('tau')
+par.update(dict(val=224.16634713698585, min=2.0, max=300.0, fmt='{:.4g}', frozen=True))
+
+# Set step_power_2iru__4hfspat component parameters
+comp = model.get_comp('step_power_2iru__4hfspat')
+
+par = comp.get_par('P')
+par.update(dict(val=0.011488201458560068, min=-10.0, max=10.0, fmt='{:.4g}', frozen=True))
+
+# Set step_power_1iru__4hfspat component parameters
+comp = model.get_comp('step_power_1iru__4hfspat')
+
+par = comp.get_par('P')
+par.update(dict(val=-0.010011660309755826, min=-10.0, max=10.0, fmt='{:.4g}', frozen=True))
+
+model.bad_times = []
+if len(sys.argv) > 1:
+    model.write(sys.argv[1])

--- a/xija/component/base.py
+++ b/xija/component/base.py
@@ -196,7 +196,7 @@ class CmdStatesData(TelemData):
 
 class Node(TelemData):
     """Time-series dataset for prediction.
-    
+
     If the ``sigma`` value is negative then sigma is computed from the
     node data values as the specified percent of the data standard
     deviation.  The default ``sigma`` value is -10, so this implies
@@ -334,7 +334,7 @@ class Coupling(ModelComponent):
     """\
     First-order coupling between Nodes `node1` and `node2`
     ::
-    
+
       dy1/dt = -(y1 - y2) / tau
 
     Parameters
@@ -361,6 +361,23 @@ class Coupling(ModelComponent):
         return 'coupling__{0}__{1}'.format(self.node1, self.node2)
 
 
+class Delay(ModelComponent):
+    """Delay mval from ``node`` by ``delay`` ksec
+
+    See the example in examples/delay/. For a positive delay, the computed model
+    value (``node.mval``) will be constant at the initial value for the first
+    ``delay`` ksec. Conversely for a negative delay the values at the end will
+    be constant for ``delay`` ksec.
+    """
+    def __init__(self, model, node, delay=0):
+        super().__init__(model)
+        self.node = self.model.get_comp(node)
+        self.add_par('delay', delay, min=-40, max=40)
+
+    def __str__(self):
+        return f'delay__{self.node}'
+
+
 class HeatSink(ModelComponent):
     """Fixed temperature external heat bath"""
     def __init__(self, model, node, T=0.0, tau=20.0):
@@ -384,13 +401,13 @@ class HeatSinkRef(ModelComponent):
     tau does not affect the mean model temperature.  This requires an extra
     non-fitted parameter T_ref which corresponds to a reference temperature for
     the node.::
-    
+
       dT/dt = U * (Te - T)
             = P + U* (T_ref - T)   # reparameterization
-    
+
       P = U * (Te - T_ref)
       Te = P / U + T_ref
-    
+
     In code below, "T" corresponds to "Te" above.  The "T" above is node.dvals.
 
     Parameters

--- a/xija/model.py
+++ b/xija/model.py
@@ -696,6 +696,14 @@ class XijaModel(object):
         # hackish fix to ensure last value is computed
         self.mvals[:, -1] = self.mvals[:, -2]
 
+        # Apply Delay components after the model calculation
+        for comp in self.comps:
+            if isinstance(comp, component.Delay) and comp.delay != 0.0:
+                # Note: starting from index 0 creates an instability in xija_gui_fit,
+                # so just copy from index 1.
+                comp.node.mvals[1:] = np.interp(x=self.times - comp.delay * 1000,
+                                                xp=self.times, fp=comp.node.mvals)[1:]
+
     def calc_stat(self):
         """Calculate model fit statistic as the sum of component fit stats"""
         self.calc()            # parvals already set with dummy_calc


### PR DESCRIPTION
## Description

Add a new model component class `Delay` to delay the compute model values from ``node`` by ``delay`` ksec.

For a positive delay, the computed model value (`node.mval`) will be constant at the initial value for the first `delay` ksec. Conversely for a negative delay the values at the end will  be constant for `delay` ksec.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing

### Functional testing

Made a new thermal model for 4HFSPAT using the `Delay` component (now included in the `examples/delay` directory).
- Confirmed that the model component introduces the expected positive or negative delay, with the endpoints being fixed as expected. 
- Confirmed that the `delay` parameter can be successfully fit with `xija_gui_fit` and that the result is reasonable (i.e. the model and data peaks visually line up).