### PR TITLE
Fix random crashes using xija_gui_fit on Linux, change limit names for annotation, use CxoTime

### DIFF
--- a/xija/gui_fit/app.py
+++ b/xija/gui_fit/app.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import os
 import ast

--- a/xija/gui_fit/app.py
+++ b/xija/gui_fit/app.py
@@ -1192,7 +1192,7 @@ def main():
     gui_config['filename'] = os.path.abspath(opt.filename)
     gui_config['set_data_vals'] = set_data_vals
 
-    fit_worker = FitWorker(model, opt.maxiter)
+    fit_worker = FitWorker(model, opt.maxiter, method=opt.fit_method)
 
     model.calc()
 

--- a/xija/gui_fit/app.py
+++ b/xija/gui_fit/app.py
@@ -18,10 +18,7 @@ from cxotime import CxoTime
 
 import pyyaks.context as pyc
 
-try:
-    import acis_taco as taco
-except ImportError:
-    import Chandra.taco as taco
+import acis_taco as taco
 import xija
 
 from xija.component.base import Node, TelemData

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -419,7 +419,7 @@ class PlotBox(QtWidgets.QVBoxLayout):
 
     def select(self, event):
         grab = event.inaxes and self.main_window.show_line and \
-               self.canvas.toolbar._active is None
+               not self.ax.get_navigate_mode()
         if grab:
             self.mover = self.canvas.mpl_connect('motion_notify_event', self.on_mouse_move)
             self.plots_box.xline = event.xdata

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -160,6 +160,59 @@ def clearLayout(layout):
                 clearLayout(item.layout())
 
 
+def annotate_limits(limits, ax, dir='h'):
+    if len(limits) == 0:
+        return []
+    lines = []
+    draw_line = getattr(ax, f'ax{dir}line')
+    if 'acisi_data_quality' in limits:
+        lines.append(
+            draw_line(limits['acisi_data_quality'],
+                      ls='-.', color='blue')
+        )
+    if 'aciss_data_quality' in limits:
+        lines.append(
+            draw_line(limits['aciss_data_quality'],
+                      ls='-.', color='purple')
+        )
+    if 'planning_caution_high' in limits:
+        lines.append(
+            draw_line(limits['planning_caution_high'],
+                      ls='-.', color='gray')
+        )
+    if 'planning_warning_low' in limits:
+        lines.append(
+            draw_line(limits['planning_warning_low'],
+                      ls='-', color='green')
+        )
+    if 'planning_warning_high' in limits:
+        lines.append(
+            draw_line(limits['planning_warning_high'],
+                      ls='-', color='green')
+        )
+    if 'odb_caution_low' in limits:
+        lines.append(
+            draw_line(limits['odb_caution_low'],
+                      ls='-', color='gold')
+        )
+    if 'odb_caution_high' in limits:
+        lines.append(
+            draw_line(limits['odb_caution_high'],
+                      ls='-', color='gold')
+        )
+    if 'odb_warning_low' in limits:
+        lines.append(
+            draw_line(limits['odb_warning_low'],
+                      ls='-', color='red')
+        )
+    if 'odb_warning_high' in limits:
+        lines.append(
+            draw_line(limits['odb_warning_high'],
+                      ls='-', color='red')
+        )
+    return lines
+
+
 class MplCanvas(FigureCanvas):
     """Ultimately, this is a QWidget (as well as a FigureCanvasAgg, etc.)."""
     def __init__(self, parent=None):
@@ -283,8 +336,8 @@ class HistogramWindow(QtWidgets.QMainWindow):
 
     def plot_limits(self, state):
         if state == QtCore.Qt.Checked:
-            self.limit_lines = self.model.annotate_limits(
-                self.hist_msids[self.which_msid], self.ax1)
+            limits = self.model.limits[self.hist_msids[self.which_msid]]
+            self.limit_lines = annotate_limits(limits, self.ax1)
         else:
             [line.remove() for line in self.limit_lines]
             self.limit_lines = []
@@ -500,12 +553,11 @@ class PlotBox(QtWidgets.QVBoxLayout):
 
     def add_annotation(self, atype):
         if atype == "limits" and self.comp_name in self.plots_box.model.limits:
+            limits = self.plots_box.model.limits[self.comp_name]
             if "resid__data" in self.plot_name:
-                self.limits = self.plots_box.model.annotate_limits(
-                    self.comp_name, self.ax, dir='v')
+                self.limits = annotate_limits(limits, self.ax, dir='v')
             elif "data__time" in self.plot_name:
-                self.limits = self.plots_box.model.annotate_limits(
-                    self.comp_name, self.ax, dir='h')
+                self.limits = annotate_limits(limits, self.ax, dir='h')
         elif atype == "radzones" and self.plot_method.endswith("time"):
             rad_zones = get_radzones(self.plots_box.model)
             self.rzlines = []

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -174,7 +174,8 @@ def annotate_limits(limits, ax, dir='h'):
         ('odb.caution.low', '-', 'gold'),
         ('odb.caution.high', '-', 'gold'),
         ('odb.warning.low', '-', 'red'),
-        ('odb.warning.high', '-', 'red')
+        ('odb.warning.high', '-', 'red'),
+        ('planning.zero_feps.low', '--', 'dodgerblue')
     ]
     for (limit_name, ls, color) in opts:
         if limit_name in limits:

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -165,49 +165,49 @@ def annotate_limits(limits, ax, dir='h'):
         return []
     lines = []
     draw_line = getattr(ax, f'ax{dir}line')
-    if 'acisi_data_quality' in limits:
+    if 'planning.data_quality.high.acisi' in limits:
         lines.append(
-            draw_line(limits['acisi_data_quality'],
+            draw_line(limits['planning.data_quality.high.acisi'],
                       ls='-.', color='blue')
         )
-    if 'aciss_data_quality' in limits:
+    if 'planning.data_quality.high.aciss' in limits:
         lines.append(
-            draw_line(limits['aciss_data_quality'],
+            draw_line(limits['planning.data_quality.high.aciss'],
                       ls='-.', color='purple')
         )
-    if 'planning_caution_high' in limits:
+    if 'planning.penalty.high' in limits:
         lines.append(
-            draw_line(limits['planning_caution_high'],
+            draw_line(limits['planning.penalty.high'],
                       ls='-.', color='gray')
         )
-    if 'planning_warning_low' in limits:
+    if 'planning.warning.low' in limits:
         lines.append(
-            draw_line(limits['planning_warning_low'],
+            draw_line(limits['planning.warning.low'],
                       ls='-', color='green')
         )
-    if 'planning_warning_high' in limits:
+    if 'planning.warning.high' in limits:
         lines.append(
-            draw_line(limits['planning_warning_high'],
+            draw_line(limits['planning.warning.high'],
                       ls='-', color='green')
         )
-    if 'odb_caution_low' in limits:
+    if 'odb.caution.low' in limits:
         lines.append(
-            draw_line(limits['odb_caution_low'],
+            draw_line(limits['odb.caution.low'],
                       ls='-', color='gold')
         )
-    if 'odb_caution_high' in limits:
+    if 'odb.caution.high' in limits:
         lines.append(
-            draw_line(limits['odb_caution_high'],
+            draw_line(limits['odb.caution.high'],
                       ls='-', color='gold')
         )
-    if 'odb_warning_low' in limits:
+    if 'odb.warning.low' in limits:
         lines.append(
-            draw_line(limits['odb_warning_low'],
+            draw_line(limits['odb.warning.low'],
                       ls='-', color='red')
         )
-    if 'odb_warning_high' in limits:
+    if 'odb.warning.high' in limits:
         lines.append(
-            draw_line(limits['odb_warning_high'],
+            draw_line(limits['odb.warning.high'],
                       ls='-', color='red')
         )
     return lines

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -412,7 +412,7 @@ class HistogramWindow(QtWidgets.QMainWindow):
         self.plot_dict["fill"] = self.ax2.fill_between(
             bin_mid, hist, step="mid", color='#386cb0')
 
-        self.ax2.set_ylim(0.0, None)
+        self.ax2.set_ylim(0.0, hist.max()+1)
 
         # Print labels for statistical boundaries.
         ylim2 = self.ax2.get_ylim()

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -283,7 +283,8 @@ class HistogramWindow(QtWidgets.QMainWindow):
 
     def plot_limits(self, state):
         if state == QtCore.Qt.Checked:
-            self.limit_lines = self.model.annotate_limits(self.ax1)
+            self.limit_lines = self.model.annotate_limits(
+                self.hist_msids[self.which_msid], self.ax1)
         else:
             [line.remove() for line in self.limit_lines]
             self.limit_lines = []
@@ -499,12 +500,12 @@ class PlotBox(QtWidgets.QVBoxLayout):
 
     def add_annotation(self, atype):
         if atype == "limits" and self.comp_name in self.plots_box.model.limits:
-            if self.plot_method.endswith("resid__data"):
-                which_dir = 'v'
-            elif self.plot_method.endswith("data__time"):
-                which_dir = 'h'
-            self.limits = self.plots_box.model.annotate_limits(
-                self.comp_name, self.ax, dir=which_dir)
+            if "resid__data" in self.plot_name:
+                self.limits = self.plots_box.model.annotate_limits(
+                    self.comp_name, self.ax, dir='v')
+            elif "data__time" in self.plot_name:
+                self.limits = self.plots_box.model.annotate_limits(
+                    self.comp_name, self.ax, dir='h')
         elif atype == "radzones" and self.plot_method.endswith("time"):
             rad_zones = get_radzones(self.plots_box.model)
             self.rzlines = []

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -247,6 +247,7 @@ class HistogramWindow(QtWidgets.QMainWindow):
         self.make_plots()
 
     def close_window(self, *args):
+        self.fig.clear()
         self.close()
 
     _rz_mask = None
@@ -366,7 +367,7 @@ class HistogramWindow(QtWidgets.QMainWindow):
             self.ax2.text(np.max(resids) - xoffset * 0.9, ystart,
                      'Maximum Error', ha="left",
                      va="center", rotation=90)
-        
+
         self.canvas.draw_idle()
 
 

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -165,51 +165,22 @@ def annotate_limits(limits, ax, dir='h'):
         return []
     lines = []
     draw_line = getattr(ax, f'ax{dir}line')
-    if 'planning.data_quality.high.acisi' in limits:
-        lines.append(
-            draw_line(limits['planning.data_quality.high.acisi'],
-                      ls='-.', color='blue')
-        )
-    if 'planning.data_quality.high.aciss' in limits:
-        lines.append(
-            draw_line(limits['planning.data_quality.high.aciss'],
-                      ls='-.', color='purple')
-        )
-    if 'planning.penalty.high' in limits:
-        lines.append(
-            draw_line(limits['planning.penalty.high'],
-                      ls='-.', color='gray')
-        )
-    if 'planning.warning.low' in limits:
-        lines.append(
-            draw_line(limits['planning.warning.low'],
-                      ls='-', color='green')
-        )
-    if 'planning.warning.high' in limits:
-        lines.append(
-            draw_line(limits['planning.warning.high'],
-                      ls='-', color='green')
-        )
-    if 'odb.caution.low' in limits:
-        lines.append(
-            draw_line(limits['odb.caution.low'],
-                      ls='-', color='gold')
-        )
-    if 'odb.caution.high' in limits:
-        lines.append(
-            draw_line(limits['odb.caution.high'],
-                      ls='-', color='gold')
-        )
-    if 'odb.warning.low' in limits:
-        lines.append(
-            draw_line(limits['odb.warning.low'],
-                      ls='-', color='red')
-        )
-    if 'odb.warning.high' in limits:
-        lines.append(
-            draw_line(limits['odb.warning.high'],
-                      ls='-', color='red')
-        )
+    opts = [
+        ('planning.data_quality.high.acisi', '-.', 'blue'),
+        ('planning.data_quality.high.aciss', '-.', 'purple'),
+        ('planning.penalty.high', '-.', 'gray'),
+        ('planning.warning.low', '-', 'green'),
+        ('planning.warning.high', '-', 'green'),
+        ('odb.caution.low', '-', 'gold'),
+        ('odb.caution.high', '-', 'gold'),
+        ('odb.warning.low', '-', 'red'),
+        ('odb.warning.high', '-', 'red')
+    ]
+    for (limit_name, ls, color) in opts:
+        if limit_name in limits:
+            lines.append(
+                draw_line(limits[limit_name], ls=ls, color=color)
+            )
     return lines
 
 
@@ -223,7 +194,7 @@ class MplCanvas(FigureCanvas):
         self.setSizePolicy(QtWidgets.QSizePolicy.Expanding,
                            QtWidgets.QSizePolicy.Expanding)
         self.updateGeometry()
-        
+
 
 class HistogramWindow(QtWidgets.QMainWindow):
     def __init__(self, model, hist_msids):
@@ -297,8 +268,8 @@ class HistogramWindow(QtWidgets.QMainWindow):
         self.limit_lines = []
 
         self.canvas = canvas
-        self.ax1 = self.canvas.fig.add_subplot(121)
-        self.ax2 = self.canvas.fig.add_subplot(122)
+        self.ax1 = self.canvas.fig.add_subplot(1, 2, 1)
+        self.ax2 = self.canvas.fig.add_subplot(1, 2, 2)
         self.plot_dict = {}
         self.make_plots()
 

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -413,7 +413,7 @@ class HistogramWindow(QtWidgets.QMainWindow):
         self.plot_dict["fill"] = self.ax2.fill_between(
             bin_mid, hist, step="mid", color='#386cb0')
 
-        self.ax2.set_ylim(0.0, hist.max()+1)
+        self.ax2.set_ylim(0.0, np.nanmax(hist)+1)
 
         # Print labels for statistical boundaries.
         ylim2 = self.ax2.get_ylim()

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -170,9 +170,6 @@ class MplCanvas(FigureCanvas):
         self.setSizePolicy(QtWidgets.QSizePolicy.Expanding,
                            QtWidgets.QSizePolicy.Expanding)
         self.updateGeometry()
-
-    #def draw_idle(self):
-    #    QtCore.QTimer.singleShot(1000, super().draw_idle)
         
 
 class HistogramWindow(QtWidgets.QMainWindow):
@@ -278,11 +275,11 @@ class HistogramWindow(QtWidgets.QMainWindow):
 
     def mask_fmt1(self, state):
         self.fmt1_masked = state == QtCore.Qt.Checked
-        QtCore.QTimer.singleShot(0, self.update_plots)
+        QtCore.QTimer.singleShot(200, self.update_plots)
 
     def mask_radzones(self, state):
         self.rz_masked = state == QtCore.Qt.Checked
-        QtCore.QTimer.singleShot(0, self.update_plots)
+        QtCore.QTimer.singleShot(200, self.update_plots)
 
     def plot_limits(self, state):
         if state == QtCore.Qt.Checked:
@@ -297,7 +294,7 @@ class HistogramWindow(QtWidgets.QMainWindow):
         self.comp = self.model.comp[self.hist_msids[self.which_msid]]
         msid_name = self.hist_msids[self.which_msid]
         self.ax1.set_title(f'{msid_name}: data vs. residuals (data - model)')
-        QtCore.QTimer.singleShot(0, self.update_plots)
+        QtCore.QTimer.singleShot(200, self.update_plots)
 
     def make_plots(self):
         msid_name = self.hist_msids[self.which_msid]

--- a/xija/model.py
+++ b/xija/model.py
@@ -789,54 +789,55 @@ class XijaModel(object):
         self.mask_times_indices = self.bad_times_indices.copy()
         self.mask_time_secs = date2secs(self.mask_times)
 
-    def annotate_limits(self, ax, dir='h'):
-        if len(self.limits) == 0:
+    def annotate_limits(self, msid, ax, dir='h'):
+        limits = self.limits[msid]
+        if len(limits) == 0:
             return []
         lines = []
         draw_line = getattr(ax, f'ax{dir}line')
-        if 'acisi_data_quality' in self.limits:
+        if 'acisi_data_quality' in limits:
             lines.append(
-                draw_line(self.limits['acisi_data_quality'], 
+                draw_line(limits['acisi_data_quality'], 
                           ls='-.', color='blue')
             )
-        if 'aciss_data_quality' in self.limits:
+        if 'aciss_data_quality' in limits:
             lines.append(
-                draw_line(self.limits['aciss_data_quality'], 
+                draw_line(limits['aciss_data_quality'], 
                           ls='-.', color='purple')
             )
-        if 'planning_caution_high' in self.limits:
+        if 'planning_caution_high' in limits:
             lines.append(
-                draw_line(self.limits['planning_caution_high'], 
+                draw_line(limits['planning_caution_high'], 
                           ls='-.', color='gray')
             )
-        if 'planning_warning_low' in self.limits:
+        if 'planning_warning_low' in limits:
             lines.append(
-                draw_line(self.limits['planning_warning_low'], 
+                draw_line(limits['planning_warning_low'], 
                           ls='-', color='green')
             )
-        if 'planning_warning_high' in self.limits:
+        if 'planning_warning_high' in limits:
             lines.append(
-                draw_line(self.limits['planning_warning_high'], 
+                draw_line(limits['planning_warning_high'], 
                           ls='-', color='green')
             )
-        if 'odb_caution_low' in self.limits:
+        if 'odb_caution_low' in limits:
             lines.append(
-                draw_line(self.limits['odb_caution_low'], 
+                draw_line(limits['odb_caution_low'], 
                           ls='-', color='gold')
             )
-        if 'odb_caution_high' in self.limits:
+        if 'odb_caution_high' in limits:
             lines.append(
-                draw_line(self.limits['odb_caution_high'], 
+                draw_line(limits['odb_caution_high'], 
                           ls='-', color='gold')
             )
-        if 'odb_warning_low' in self.limits:
+        if 'odb_warning_low' in limits:
             lines.append(
-                draw_line(self.limits['odb_warning_low'], 
+                draw_line(limits['odb_warning_low'], 
                           ls='-', color='red')
             )
-        if 'odb_warning_high' in self.limits:
+        if 'odb_warning_high' in limits:
             lines.append(
-                draw_line(self.limits['odb_warning_high'], 
+                draw_line(limits['odb_warning_high'], 
                           ls='-', color='red')
             )
         return lines

--- a/xija/model.py
+++ b/xija/model.py
@@ -791,25 +791,54 @@ class XijaModel(object):
 
     def annotate_limits(self, ax, dir='h'):
         if len(self.limits) == 0:
-            return
+            return []
+        lines = []
         draw_line = getattr(ax, 'ax{}line'.format(dir))
         if 'acisi_data_quality' in self.limits:
-            draw_line(self.limits['acisi_data_quality'], ls='-.', color='blue')
+            lines.append(
+                draw_line(self.limits['acisi_data_quality'], 
+                          ls='-.', color='blue')
+            )
         if 'aciss_data_quality' in self.limits:
-            draw_line(self.limits['aciss_data_quality'], ls='-.', color='purple')
+            lines.append(
+                draw_line(self.limits['aciss_data_quality'], 
+                          ls='-.', color='purple')
+            )
         if 'planning_caution_high' in self.limits:
-            draw_line(self.limits['planning_caution_high'], ls='-.', color='gray')
+            lines.append(
+                draw_line(self.limits['planning_caution_high'], 
+                          ls='-.', color='gray')
+            )
         if 'planning_warning_low' in self.limits:
-            draw_line(self.limits['planning_warning_low'], ls='-', color='green')
+            lines.append(
+                draw_line(self.limits['planning_warning_low'], 
+                          ls='-', color='green')
+            )
         if 'planning_warning_high' in self.limits:
-            draw_line(self.limits['planning_warning_high'], ls='-', color='green')
+            lines.append(
+                draw_line(self.limits['planning_warning_high'], 
+                          ls='-', color='green')
+            )
         if 'odb_caution_low' in self.limits:
-            draw_line(self.limits['odb_caution_low'], ls='-', color='gold')
+            lines.append(
+                draw_line(self.limits['odb_caution_low'], 
+                          ls='-', color='gold')
+            )
         if 'odb_caution_high' in self.limits:
-            draw_line(self.limits['odb_caution_high'], ls='-', color='gold')
+            lines.append(
+                draw_line(self.limits['odb_caution_high'], 
+                          ls='-', color='gold')
+            )
         if 'odb_warning_low' in self.limits:
-            draw_line(self.limits['odb_warning_low'], ls='-', color='red')
+            lines.append(
+                draw_line(self.limits['odb_warning_low'], 
+                          ls='-', color='red')
+            )
         if 'odb_warning_high' in self.limits:
-            draw_line(self.limits['odb_warning_high'], ls='-', color='red')
+            lines.append(
+                draw_line(self.limits['odb_warning_high'], 
+                          ls='-', color='red')
+            )
+        return lines
 
 ThermalModel = XijaModel

--- a/xija/model.py
+++ b/xija/model.py
@@ -789,57 +789,5 @@ class XijaModel(object):
         self.mask_times_indices = self.bad_times_indices.copy()
         self.mask_time_secs = date2secs(self.mask_times)
 
-    def annotate_limits(self, msid, ax, dir='h'):
-        limits = self.limits[msid]
-        if len(limits) == 0:
-            return []
-        lines = []
-        draw_line = getattr(ax, f'ax{dir}line')
-        if 'acisi_data_quality' in limits:
-            lines.append(
-                draw_line(limits['acisi_data_quality'], 
-                          ls='-.', color='blue')
-            )
-        if 'aciss_data_quality' in limits:
-            lines.append(
-                draw_line(limits['aciss_data_quality'], 
-                          ls='-.', color='purple')
-            )
-        if 'planning_caution_high' in limits:
-            lines.append(
-                draw_line(limits['planning_caution_high'], 
-                          ls='-.', color='gray')
-            )
-        if 'planning_warning_low' in limits:
-            lines.append(
-                draw_line(limits['planning_warning_low'], 
-                          ls='-', color='green')
-            )
-        if 'planning_warning_high' in limits:
-            lines.append(
-                draw_line(limits['planning_warning_high'], 
-                          ls='-', color='green')
-            )
-        if 'odb_caution_low' in limits:
-            lines.append(
-                draw_line(limits['odb_caution_low'], 
-                          ls='-', color='gold')
-            )
-        if 'odb_caution_high' in limits:
-            lines.append(
-                draw_line(limits['odb_caution_high'], 
-                          ls='-', color='gold')
-            )
-        if 'odb_warning_low' in limits:
-            lines.append(
-                draw_line(limits['odb_warning_low'], 
-                          ls='-', color='red')
-            )
-        if 'odb_warning_high' in limits:
-            lines.append(
-                draw_line(limits['odb_warning_high'], 
-                          ls='-', color='red')
-            )
-        return lines
 
 ThermalModel = XijaModel

--- a/xija/model.py
+++ b/xija/model.py
@@ -793,7 +793,7 @@ class XijaModel(object):
         if len(self.limits) == 0:
             return []
         lines = []
-        draw_line = getattr(ax, 'ax{}line'.format(dir))
+        draw_line = getattr(ax, f'ax{dir}line')
         if 'acisi_data_quality' in self.limits:
             lines.append(
                 draw_line(self.limits['acisi_data_quality'], 


### PR DESCRIPTION
## Description

This PR resolves an issue where `xija_gui_fit` would seemingly randomly crash on Linux when manipulating plots. The exact reason is unknown, because I could never seem to produce a traceback of any kind, but many of the plot objects (such as `Figure` and `Axes` were being re-created every time the data itself needed an update due to a new model fit, etc. This PR implements the changing of the data on the plot itself (for several plot types) instead of re-creating the plot objects with every update, which appears to fix the problem. 

This PR also does the following:

* Uses `CxoTime` instead of `Chandra.Time`
* `annotate_limits` has been moved from being a method of the `XijaModel` class to being a function in the `xija_gui_fit` app, since this is the only place it's used
* Removes old attempt at import of `Chandra.taco` which is a ska2 remnant
* Implement the names for limit values suggested in when plotting them https://github.com/sot/xija/issues/70#issuecomment-780108818

## Testing

- [x] Passes unit tests on macOS
- [x] Functional testing on Linux and macOS (with independent testing from @taldcroft)

Fixes issue #105.