### PR TITLE
This fixes a bug that was missed in the recent gui_fit PR

### DIFF
--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -544,12 +544,14 @@ class PlotBox(QtWidgets.QVBoxLayout):
 
     def remove_annotation(self, atype):
         if atype == "limits" and self.comp_name in self.plots_box.model.limits:
-            [line.remove() for line in self.limits]
-            self.limits = None
+            if self.limits is not None:
+                [line.remove() for line in self.limits]
+                self.limits = None
         elif atype == "radzones" and self.plot_method.endswith("time"):
-            [line.remove() for line in self.rzlines]
-            self.rzlines = None
-        elif atype == "line":
+            if self.rzlines is not None:
+                [line.remove() for line in self.rzlines]
+                self.rzlines = None
+        elif atype == "line" and self.ly is not None:
             self.ly.remove()
             self.ly = None
     


### PR DESCRIPTION
## Description

This fixes a bug in `xija_gui_fit` that was missed in the last PR. The bug surfaces when one toggles the limit lines on and off, and causes a crash. 

## Testing

- [ ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing