### PR TITLE
Set the default repo_path inside the get_model_spec function

### DIFF
--- a/xija/get_model_spec.py
+++ b/xija/get_model_spec.py
@@ -92,7 +92,7 @@ def get_xija_model_spec(model_name, version=None, repo_path=None,
 
     Returns
     -------
-    tuple of dict, str, str
+    tuple of dict, str
         Xija model specification dict, chandra_models version
     """
     if repo_path is None:

--- a/xija/get_model_spec.py
+++ b/xija/get_model_spec.py
@@ -42,8 +42,8 @@ def temp_directory():
     shutil.rmtree(tmpdir, ignore_errors=True)
 
 
-def get_xija_model_spec(model_name, version=None, repo_path=REPO_PATH,
-                        check_version=False, timeout=5) -> dict:
+def get_xija_model_spec(model_name, version=None, repo_path=None,
+                        check_version=False, timeout=5) -> tuple:
     """
     Get Xija model specification for the specified ``model_name``.
 
@@ -92,16 +92,20 @@ def get_xija_model_spec(model_name, version=None, repo_path=REPO_PATH,
 
     Returns
     -------
-    dict, str
-        Xija model specification dict, chandra_models version
+    tuple of dict, str, str
+        Xija model specification dict, chandra_models version, path to model spec
+        file used
     """
+    if repo_path is None:
+        repo_path = REPO_PATH
     with temp_directory() as repo_path_local:
         repo = git.Repo.clone_from(repo_path, repo_path_local)
         if version is not None:
             repo.git.checkout(version)
-        model_spec, version = _get_xija_model_spec(model_name, version, repo_path_local,
-                                                   check_version, timeout)
-    return model_spec, version
+        model_spec, version, model_spec_path = _get_xija_model_spec(
+            model_name, version, repo_path_local, check_version, timeout)
+
+    return model_spec, version, model_spec_path
 
 
 def _get_xija_model_spec(model_name, version=None, repo_path=REPO_PATH,
@@ -136,7 +140,7 @@ def _get_xija_model_spec(model_name, version=None, repo_path=REPO_PATH,
             raise ValueError(f'version mismatch: local repo {version} vs '
                              f'github {gh_version}')
 
-    return model_spec, version
+    return model_spec, version, file_name
 
 
 def get_xija_model_names(repo_path=REPO_PATH) -> List[str]:

--- a/xija/get_model_spec.py
+++ b/xija/get_model_spec.py
@@ -93,8 +93,7 @@ def get_xija_model_spec(model_name, version=None, repo_path=None,
     Returns
     -------
     tuple of dict, str, str
-        Xija model specification dict, chandra_models version, path to model spec
-        file used
+        Xija model specification dict, chandra_models version
     """
     if repo_path is None:
         repo_path = REPO_PATH
@@ -102,10 +101,9 @@ def get_xija_model_spec(model_name, version=None, repo_path=None,
         repo = git.Repo.clone_from(repo_path, repo_path_local)
         if version is not None:
             repo.git.checkout(version)
-        model_spec, version, model_spec_path = _get_xija_model_spec(
-            model_name, version, repo_path_local, check_version, timeout)
-
-    return model_spec, version, model_spec_path
+        model_spec, version = _get_xija_model_spec(model_name, version, repo_path_local,
+                                                   check_version, timeout)
+    return model_spec, version
 
 
 def _get_xija_model_spec(model_name, version=None, repo_path=REPO_PATH,
@@ -140,7 +138,7 @@ def _get_xija_model_spec(model_name, version=None, repo_path=REPO_PATH,
             raise ValueError(f'version mismatch: local repo {version} vs '
                              f'github {gh_version}')
 
-    return model_spec, version, file_name
+    return model_spec, version
 
 
 def get_xija_model_names(repo_path=REPO_PATH) -> List[str]:


### PR DESCRIPTION
## Description

This PR makes ~~two changes~~ one minor change to `xija.get_model_spec`. ~~one minor and another that is API-breaking~~ 

1. Let the default for `repo_path` be `None` and then set it to `REPO_PATH` internally, so that calling routines from other packages can pass a `None` as default and they won't need to know about `REPO_PATH`.
~~2. In a couple of cases, I have found that it would be nice to know the path to the JSON file returned by `get_model_spec`, so it can be reported in logging or print statements. The way I currently do this is rather clunky--I import `REPO_PATH` from the same module. But this duplicates what's already being done in the function and is error-prone if something changes. So this change simply returns the path as the third argument--unfortunately this also breaks API.~~

~~If anyone can think of a non-API-breaking way to achieve the second change, let me know.~~