### PR TITLE
Use the right repo path to get available model names

### DIFF
--- a/xija/get_model_spec.py
+++ b/xija/get_model_spec.py
@@ -117,7 +117,7 @@ def _get_xija_model_spec(model_name, version=None, repo_path=REPO_PATH,
         # get_globfiles() default requires exactly one file match and returns a list
         file_name = get_globfiles(file_glob)[0]
     except ValueError:
-        names = get_xija_model_names()
+        names = get_xija_model_names(repo_path)
         raise ValueError(f'no models matched {model_name}. Available models are: '
                          f'{", ".join(names)}')
 


### PR DESCRIPTION
## Description

The helper code to get the available model names in case of a bad input name was missing the `repo_path`.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

### Functional testing
```
(ska3) ➜  xija git:(get-model-spec-error-reporting) ✗ ipython
Python 3.8.3 (default, Jul  2 2020, 11:26:31) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from xija.get_model_spec import get_xija_model_spec                                                                                  
```
#### Case with good name
```
In [2]: spec, version = get_xija_model_spec('bep_pcb', version='bep_fep')                                                                    
```
#### Case with bad name. Note that the available models include the new BEP/FEP models
```
In [3]: spec, version = get_xija_model_spec('bep_pab', version='bep_fep')                                                                    
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
~/git/xija/xija/get_model_spec.py in _get_xija_model_spec(model_name, version, repo_path, check_version, timeout)
    117         # get_globfiles() default requires exactly one file match and returns a list
--> 118         file_name = get_globfiles(file_glob)[0]
    119     except ValueError:

~/miniconda3/envs/ska3/lib/python3.8/site-packages/Ska/File.py in get_globfiles(fileglob, minfiles, maxfiles)
     68     if minfiles is not None and nfiles < minfiles:
---> 69         raise ValueError('At least %d file(s) required for %s but %d found' % (minfiles, fileglob, nfiles))
     70     if maxfiles is not None and nfiles > maxfiles:

ValueError: At least 1 file(s) required for /var/folders/zn/910d7qgd1ydd4bvww62b6b9r0000gp/T/tmpdfs598fw/chandra_models/xija/*/bep_pab_spec.json but 0 found

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
<ipython-input-3-5e4ab493abcc> in <module>
----> 1 spec, version = get_xija_model_spec('bep_pab', version='bep_fep')

~/git/xija/xija/get_model_spec.py in get_xija_model_spec(model_name, version, repo_path, check_version, timeout)
    100         if version is not None:
    101             repo.git.checkout(version)
--> 102         model_spec, version = _get_xija_model_spec(model_name, version, repo_path_local,
    103                                                    check_version, timeout)
    104     return model_spec, version

~/git/xija/xija/get_model_spec.py in _get_xija_model_spec(model_name, version, repo_path, check_version, timeout)
    119     except ValueError:
    120         names = get_xija_model_names(repo_path)
--> 121         raise ValueError(f'no models matched {model_name}. Available models are: '
    122                          f'{", ".join(names)}')
    123 

ValueError: no models matched bep_pab. Available models are: aca, acisfp, bep_pcb, dea, dpa, fep1_actel, fep1_fb, fep1_mong, 4rt700t, minusyz, pm1thv2t, pm2thv1t, pm2thv2t, pftank2t, pline03t_model, pline04t_model, psmc, tcylaft6

```
#### Case with bad name. Available models are just the standard ones
```
In [4]: spec, version = get_xija_model_spec('bep_pab')                                                                                       
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
~/git/xija/xija/get_model_spec.py in _get_xija_model_spec(model_name, version, repo_path, check_version, timeout)
    117         # get_globfiles() default requires exactly one file match and returns a list
--> 118         file_name = get_globfiles(file_glob)[0]
    119     except ValueError:

~/miniconda3/envs/ska3/lib/python3.8/site-packages/Ska/File.py in get_globfiles(fileglob, minfiles, maxfiles)
     68     if minfiles is not None and nfiles < minfiles:
---> 69         raise ValueError('At least %d file(s) required for %s but %d found' % (minfiles, fileglob, nfiles))
     70     if maxfiles is not None and nfiles > maxfiles:

ValueError: At least 1 file(s) required for /var/folders/zn/910d7qgd1ydd4bvww62b6b9r0000gp/T/tmpvpzne50t/chandra_models/xija/*/bep_pab_spec.json but 0 found

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
<ipython-input-4-1fb43ad28468> in <module>
----> 1 spec, version = get_xija_model_spec('bep_pab')

~/git/xija/xija/get_model_spec.py in get_xija_model_spec(model_name, version, repo_path, check_version, timeout)
    100         if version is not None:
    101             repo.git.checkout(version)
--> 102         model_spec, version = _get_xija_model_spec(model_name, version, repo_path_local,
    103                                                    check_version, timeout)
    104     return model_spec, version

~/git/xija/xija/get_model_spec.py in _get_xija_model_spec(model_name, version, repo_path, check_version, timeout)
    119     except ValueError:
    120         names = get_xija_model_names(repo_path)
--> 121         raise ValueError(f'no models matched {model_name}. Available models are: '
    122                          f'{", ".join(names)}')
    123 

ValueError: no models matched bep_pab. Available models are: aca, acisfp, dea, dpa, 4rt700t, minusyz, pm1thv2t, pm2thv1t, pm2thv2t, pftank2t, pline03t_model, pline04t_model, psmc, tcylaft6
```
