### PR TITLE
Two new functions to handle limit strings, minor viz fixes for xija_gui_fit

### DIFF
--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -368,9 +368,14 @@ class HistogramWindow(QtWidgets.QMainWindow):
         min_resid = np.nanmin(resids)
         max_resid = np.nanmax(resids)
 
+        dvalsr = dvals + randx
+        
+        min_dvals = np.nanmin(dvalsr)
+        max_dvals = np.nanmax(dvalsr)
+
         if len(self.plot_dict) == 0:
             self.plot_dict['resids'] = self.ax1.plot(
-                resids, dvals + randx, 'o', color='#386cb0',
+                resids, dvalsr, 'o', color='#386cb0',
                 alpha=1, markersize=1, markeredgecolor='#386cb0')[0]
             self.plot_dict["01"] = self.ax1.plot(
                 Epoints01, Tpoints01, color='k', linewidth=4)[0]
@@ -396,7 +401,7 @@ class HistogramWindow(QtWidgets.QMainWindow):
                 max_resid, color='k', linestyle='--', 
                 linewidth=1.5, alpha=1)
         else:
-            self.plot_dict['resids'].set_data(resids, dvals + randx)
+            self.plot_dict['resids'].set_data(resids, dvalsr)
             self.plot_dict['01'].set_data(Epoints01, Tpoints01)
             self.plot_dict['99'].set_data(Epoints99, Tpoints99)
             self.plot_dict['50'].set_data(Epoints50, Tpoints50)
@@ -408,6 +413,9 @@ class HistogramWindow(QtWidgets.QMainWindow):
             self.plot_dict['min_hist'].set_xdata(min_resid)
             self.plot_dict['max_hist'].set_xdata(max_resid)
             self.plot_dict['fill'].remove()
+
+        self.ax1.set_xlim(min_resid-0.5, max_resid+0.5)
+        self.ax1.set_ylim(min_dvals-0.5, max_dvals+0.5)
 
         self.plot_dict["fill"] = self.ax2.fill_between(
             bin_mid, hist, step="mid", color='#386cb0')

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -164,6 +164,26 @@ def clearLayout(layout):
 
 
 def annotate_limits(limits, ax, dir='h'):
+    """
+    Annotate limit lines on a plot.
+    
+    Parameters
+    ----------
+    limits : dict
+        Dictionary of limits obtained from the model
+        specification file. 
+    ax : Matplotlib Axes object
+        The Axes object on which the line is to be 
+        written. 
+    dir : str, optional
+        The direction of the line, "h" for horizontal
+        or "v" for vertical. Default: "h"
+        
+    Returns
+    ------- 
+    list
+        A list of matplotlib.lines.Line2D objects
+    """
     if len(limits) == 0:
         return []
     lines = []

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -161,27 +161,17 @@ def clearLayout(layout):
 
 
 def annotate_limits(limits, ax, dir='h'):
+    from xija.limits import get_limit_color
     if len(limits) == 0:
         return []
     lines = []
     draw_line = getattr(ax, f'ax{dir}line')
-    opts = [
-        ('planning.data_quality.high.acisi', '-.', 'blue'),
-        ('planning.data_quality.high.aciss', '-.', 'purple'),
-        ('planning.penalty.high', '-.', 'gray'),
-        ('planning.warning.low', '-', 'green'),
-        ('planning.warning.high', '-', 'green'),
-        ('odb.caution.low', '-', 'gold'),
-        ('odb.caution.high', '-', 'gold'),
-        ('odb.warning.low', '-', 'red'),
-        ('odb.warning.high', '-', 'red'),
-        ('planning.zero_feps.low', '--', 'dodgerblue')
-    ]
-    for (limit_name, ls, color) in opts:
-        if limit_name in limits:
-            lines.append(
-                draw_line(limits[limit_name], ls=ls, color=color)
-            )
+    for limit in limits:
+        if limit == "unit":
+            continue
+        lines.append(
+            draw_line(limits[limit], color=get_limit_color(limit))
+        )
     return lines
 
 

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -369,7 +369,7 @@ class HistogramWindow(QtWidgets.QMainWindow):
         max_resid = np.nanmax(resids)
 
         dvalsr = dvals + randx
-        
+
         min_dvals = np.nanmin(dvalsr)
         max_dvals = np.nanmax(dvalsr)
 

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -10,6 +10,9 @@ from matplotlib.figure import Figure
 import matplotlib.dates as mdates
 
 
+from xija.limits import get_limit_color
+
+
 def digitize_data(Ttelem, nbins=50):
     """Digitize telemetry.
 
@@ -161,7 +164,6 @@ def clearLayout(layout):
 
 
 def annotate_limits(limits, ax, dir='h'):
-    from xija.limits import get_limit_color
     if len(limits) == 0:
         return []
     lines = []

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -188,11 +188,17 @@ def annotate_limits(limits, ax, dir='h'):
         return []
     lines = []
     draw_line = getattr(ax, f'ax{dir}line')
+    if limit['unit'] == "degF":
+        # convert degF to degC
+        convert = lambda x: (x - 32.0)*5.0/9.0
+    else:
+        # leave it alone
+        convert = lambda x: x
     for limit in limits:
         if limit == "unit":
             continue
         lines.append(
-            draw_line(limits[limit], color=get_limit_color(limit))
+            draw_line(convert(limits[limit]), color=get_limit_color(limit))
         )
     return lines
 

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -340,6 +340,8 @@ class HistogramWindow(QtWidgets.QMainWindow):
             mask &= self.rz_mask
         if self.fmt1_masked:
             mask &= self.fmt1_mask
+        for i0, i1 in self.model.bad_times_indices:
+            mask[i0:i1] = False
         resids = self.comp.resids[mask]
         dvals = self.comp.dvals[mask]
         randx = self.comp.randx[mask]

--- a/xija/limits.py
+++ b/xija/limits.py
@@ -9,7 +9,7 @@ def get_limit_spec(limit):
     """
     words = limit.split(".")
     if len(words) < 3:
-        raise RuntimeError(f"{limit} is not a valid limit string!")
+        raise RuntimeError(f"{limit} is not a valid limit string")
     limit_spec = {
         "system": words[0],
         "type": words[1],

--- a/xija/limits.py
+++ b/xija/limits.py
@@ -1,0 +1,58 @@
+def get_limit_spec(limit):
+    """
+    Based on an input *limit* string of the form:
+    
+    <system>.<type>.<direction>.<qualifier>    
+    
+    (where the "qualifier" element is optional) return the various pieces 
+    into a dictionary for convenience.
+    """
+    words = limit.split(".")
+    limit_spec = {
+        "system": words[0],
+        "type": words[1],
+        "direction": words[2]
+    }
+    if len(words) == 4:
+        limit_spec["qualifier"] = words[3]
+    else:
+        limit_spec["qualifier"] = None
+    return limit_spec
+
+
+def get_limit_color(limit):
+    """
+    Based on an input *limit* string of the form:
+    
+    <system>.<type>.<direction>.<qualifier>    
+    
+    (where the "qualifier" element is optional) return the color to
+    be used for plotting.
+    """
+    limit_spec = get_limit_spec(limit)
+    if limit_spec["qualifier"] is not None:
+        if limit_spec["qualifier"].startswith("acis") or \
+            limit_spec["qualifier"] == "cold_ecs":
+            # ACIS FP limits have their own colors
+            color = {
+                "acisi": "blue",
+                "aciss": "purple",
+                "aciss_hot": "red",
+                "cold_ecs": "dodgerblue"
+            }[limit_spec["qualifier"]]
+    elif limit_spec["system"] in ["odb", "safety"]:
+        # ODB and safety limits are yellow/red
+        color = {
+            "caution": "gold",
+            "warning": "red"
+        }[limit_spec["type"]]
+    elif limit_spec["system"] == "planning":
+        # Planning limits are green, dodgerblue, or gray 
+        color = {
+            "caution": "dodgerblue",
+            "warning": "green",
+            "penalty": "gray"
+        }[limit_spec["type"]]
+    else:
+        raise RuntimeError(f"limit \"{limit}\" is unknown!")
+    return color

--- a/xija/limits.py
+++ b/xija/limits.py
@@ -22,6 +22,21 @@ def get_limit_spec(limit):
     return limit_spec
 
 
+limit_colors = {
+    '.*.acisi': 'blue', 
+    '.*.aciss': 'purple',
+    '.*.aciss_hot': 'red',
+    '.*.cold_ecs': 'dodgerblue',
+    'odb.caution.*': 'gold',
+    'safety.caution.*': 'gold',
+    'odb.warning.*': 'red',
+    'safety.warning.*': 'red',
+    'planning.caution.*': 'dodgerblue',
+    'planning.warning.*': 'green',
+    'planning.penalty.*': 'gray'
+}
+
+
 def get_limit_color(limit):
     """
     Based on an input *limit* string of the form:
@@ -31,32 +46,9 @@ def get_limit_color(limit):
     (where the "qualifier" element is optional) return the color to
     be used for plotting.
     """
-    import warnings
-    limit_spec = get_limit_spec(limit)
-    if limit_spec["qualifier"] is not None:
-        if limit_spec["qualifier"].startswith("acis") or \
-            limit_spec["qualifier"] == "cold_ecs":
-            # ACIS FP limits have their own colors
-            color = {
-                "acisi": "blue",
-                "aciss": "purple",
-                "aciss_hot": "red",
-                "cold_ecs": "dodgerblue"
-            }[limit_spec["qualifier"]]
-    elif limit_spec["system"] in ["odb", "safety"]:
-        # ODB and safety limits are yellow/red
-        color = {
-            "caution": "gold",
-            "warning": "red"
-        }[limit_spec["type"]]
-    elif limit_spec["system"] == "planning":
-        # Planning limits are green, dodgerblue, or gray 
-        color = {
-            "caution": "dodgerblue",
-            "warning": "green",
-            "penalty": "gray"
-        }[limit_spec["type"]]
-    else:
-        color = "C0"
-        warnings.warn(f"limit \"{limit}\" is unknown")
+    import re
+    color = "black"
+    for k, v in limit_colors.items():
+       if re.search(k, limit) is not None:
+            color = v    
     return color

--- a/xija/limits.py
+++ b/xija/limits.py
@@ -31,6 +31,7 @@ def get_limit_color(limit):
     (where the "qualifier" element is optional) return the color to
     be used for plotting.
     """
+    import warnings
     limit_spec = get_limit_spec(limit)
     if limit_spec["qualifier"] is not None:
         if limit_spec["qualifier"].startswith("acis") or \
@@ -56,5 +57,6 @@ def get_limit_color(limit):
             "penalty": "gray"
         }[limit_spec["type"]]
     else:
-        raise RuntimeError(f"limit \"{limit}\" is unknown!")
+        color = "C0"
+        warnings.warn(f"limit \"{limit}\" is unknown")
     return color

--- a/xija/limits.py
+++ b/xija/limits.py
@@ -1,3 +1,8 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from fnmatch import fnmatch
+
+
 def get_limit_spec(limit):
     """
     Based on an input *limit* string of the form:
@@ -22,18 +27,19 @@ def get_limit_spec(limit):
     return limit_spec
 
 
-limit_colors = {
-    '.*.acisi': 'blue', 
-    '.*.aciss': 'purple',
-    '.*.aciss_hot': 'red',
-    '.*.cold_ecs': 'dodgerblue',
+LIMIT_COLORS = {
+    '*.acisi': 'blue', 
+    '*.aciss': 'purple',
+    '*.aciss_hot': 'red',
+    '*.cold_ecs': 'dodgerblue',
     'odb.caution.*': 'gold',
     'safety.caution.*': 'gold',
     'odb.warning.*': 'red',
     'safety.warning.*': 'red',
     'planning.caution.*': 'dodgerblue',
     'planning.warning.*': 'green',
-    'planning.penalty.*': 'gray'
+    'planning.penalty.*': 'gray',
+    '*': 'black'
 }
 
 
@@ -46,9 +52,8 @@ def get_limit_color(limit):
     (where the "qualifier" element is optional) return the color to
     be used for plotting.
     """
-    import re
-    color = "black"
-    for k, v in limit_colors.items():
-       if re.search(k, limit) is not None:
-            color = v    
+    for k, v in LIMIT_COLORS.items():
+       if fnmatch(k, limit):
+           color = v    
+           break
     return color

--- a/xija/limits.py
+++ b/xija/limits.py
@@ -1,13 +1,15 @@
 def get_limit_spec(limit):
     """
     Based on an input *limit* string of the form:
-    
-    <system>.<type>.<direction>.<qualifier>    
-    
+
+    <system>.<type>.<direction>.<qualifier>
+
     (where the "qualifier" element is optional) return the various pieces 
     into a dictionary for convenience.
     """
     words = limit.split(".")
+    if len(words) < 3:
+        raise RuntimeError(f"{limit} is not a valid limit string!")
     limit_spec = {
         "system": words[0],
         "type": words[1],

--- a/xija/limits.py
+++ b/xija/limits.py
@@ -9,8 +9,19 @@ def get_limit_spec(limit):
 
     <system>.<type>.<direction>.<qualifier>
 
-    (where the "qualifier" element is optional) return the various pieces 
+    (where the "qualifier" element is optional) return the various pieces
     into a dictionary for convenience.
+    
+    Parameters
+    ----------
+    limit : str
+        The input limit string. 
+        
+    Returns
+    -------
+    dict
+        A dictionary specifying the names of the various pieces of the
+        limit string. 
     """
     words = limit.split(".")
     if len(words) < 3:
@@ -51,6 +62,16 @@ def get_limit_color(limit):
     
     (where the "qualifier" element is optional) return the color to
     be used for plotting.
+    
+    Parameters
+    ----------
+    limit : str
+        The input limit string. 
+        
+    Returns
+    -------
+    str
+        A string giving the color of the line. 
     """
     for k, v in LIMIT_COLORS.items():
        if fnmatch(k, limit):


### PR DESCRIPTION
## Description

Based on the new limit scheme implemented in https://github.com/sot/chandra_models/pull/75, this PR implements two new functions in xija, `get_limit_spec` and `get_limit_color`. 

`get_limit_spec` takes a limit of the form `<system>.<type>.<direction>.<qualifier>` and returns a dict with these names as the keys:

```python
from xija.limits import get_limit_spec
limit_spec = get_limit_spec("planning.data_quality.high.acisi")
print(limit_spec)
```
which gives
```pycon
{
    'system': 'planning', 
    'type': 'data_quality', 
    'direction': 'high', 
    'qualifier': 'acisi'
}
```
This may have other uses eventually, but it was useful for `get_limit_color`, which uses it to assign colors for the various limits.

`get_limit_color` is used by `xija_gui_fit` to assign limit line colors, but I'll be using and `get_limit_spec` and `get_limit_color` in `acis_thermal_check` and ACISpy. 

Functional testing consisted of running `xija_gui_fit` for every model in `chandra_models` with limits and making sure that the limit lines appeared correctly in the `data__time`, `resid__data`, and histogram plots. 

This PR also fixes a number of minor visualization issues with `xija_gui_fit`. 

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

Fixes #