### PR TITLE
Fixing bugs in limits implementation and adding them to the model info window in xija_gui_fit

### DIFF
--- a/xija/gui_fit/app.py
+++ b/xija/gui_fit/app.py
@@ -243,6 +243,18 @@ class ModelInfoWindow(QtWidgets.QMainWindow):
         main_box.addWidget(QtWidgets.QLabel("Timestep: {:.1f} s".format(model.dt)))
         main_box.addWidget(QtWidgets.QLabel("Evolve Method: Core {}".format(model.evolve_method)))
         main_box.addWidget(QtWidgets.QLabel("Runge-Kutta Order: {}".format(4 if model.rk4 else 2)))
+        for msid in self.model.limits:
+            limits = self.model.limits[msid]
+            units = limits["unit"]
+            main_box.addWidget(QtWidgets.QLabel(f"{msid.upper()} limits:"))
+        for limit, val in limits.items():
+            if limit == "unit":
+                continue
+            limit_str = f"    {limit}: {val:.1f} {units}"
+            if units == "degF":
+                valC = (val - 32.0)*5.0/9.0
+                limit_str += f" ({valC:.1f} degC)"
+            main_box.addWidget(QtWidgets.QLabel(limit_str))
         main_box.addStretch(1)
 
         close_button = QtWidgets.QPushButton('Close')

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -188,7 +188,7 @@ def annotate_limits(limits, ax, dir='h'):
         return []
     lines = []
     draw_line = getattr(ax, f'ax{dir}line')
-    if limit['unit'] == "degF":
+    if limits['unit'] == "degF":
         # convert degF to degC
         convert = lambda x: (x - 32.0)*5.0/9.0
     else:

--- a/xija/limits.py
+++ b/xija/limits.py
@@ -74,7 +74,7 @@ def get_limit_color(limit):
         A string giving the color of the line. 
     """
     for k, v in LIMIT_COLORS.items():
-       if fnmatch(k, limit):
-           color = v    
-           break
+        if fnmatch(limit, k):
+            color = v    
+            break
     return color


### PR DESCRIPTION
## Description

Hi @taldcroft, 

I should have noted after I made those pushes to #112 last night that I wasn't finished testing, my apologies. There were bugs in the implementation that are now fixed here. 

I also found it useful to add the limits to the "Model Info" window in `xija_gui_fit`--see two screenshots below. If the units are degF, the window also reports the degC values since those are used in the GUI. 

<img width="649" alt="Screen Shot 2021-08-25 at 10 33 50 AM" src="https://user-images.githubusercontent.com/1914976/130811734-9880d901-f242-4c56-9563-145bbe261531.png">
<img width="574" alt="Screen Shot 2021-08-25 at 10 10 10 AM" src="https://user-images.githubusercontent.com/1914976/130811741-a47fdec8-7ab9-4441-a45a-f9b546343cfa.png">

## Testing

- [ ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

Fixes #