### PR TITLE
Adjust earthshine effect based on Earth phase

### DIFF
--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -659,7 +659,9 @@ class EarthHeat(PrecomputedHeatPower):
 
             # This next bit optionally checks to see if the solar ephemeris
             # was passed in, and if it was it computes the fraction of the
-            # Earth's surface that is illuminated by the Sun.
+            # Earth's surface that is illuminated by the Sun. Originally
+            # discussed at:
+            # https://occweb.cfa.harvard.edu/twiki/bin/view/ThermalWG/MeetingNotes2022x03x03
             solar_xyzs = [getattr(self, f'solarephem0_{x}') for x in 'xyz']
 
             if self.use_earth_phase:

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -659,7 +659,7 @@ class EarthHeat(PrecomputedHeatPower):
             # Earth's surface that is illuminated by the Sun.
             solar_xyzs = [getattr(self, f'solarephem0_{x}') for x in 'xyz']
 
-            if not None in solar_xyzs:
+            if None not in solar_xyzs:
 
                 solars = np.array([x.dvals for x in solar_xyzs]).transpose().copy()
 

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -544,6 +544,7 @@ class EarthHeat(PrecomputedHeatPower):
 
     def __init__(self, model, node,
                  orbitephem0_x, orbitephem0_y, orbitephem0_z,
+                 solarephem0_x, solarephem0_y, solarephem0_z,
                  aoattqt1, aoattqt2, aoattqt3, aoattqt4,
                  k=1.0):
         ModelComponent.__init__(self, model)
@@ -551,6 +552,9 @@ class EarthHeat(PrecomputedHeatPower):
         self.orbitephem0_x = self.model.get_comp(orbitephem0_x)
         self.orbitephem0_y = self.model.get_comp(orbitephem0_y)
         self.orbitephem0_z = self.model.get_comp(orbitephem0_z)
+        self.solarephem0_x = self.model.get_comp(solarephem0_x)
+        self.solarephem0_y = self.model.get_comp(solarephem0_y)
+        self.solarephem0_z = self.model.get_comp(solarephem0_z)
         self.aoattqt1 = self.model.get_comp(aoattqt1)
         self.aoattqt2 = self.model.get_comp(aoattqt2)
         self.aoattqt3 = self.model.get_comp(aoattqt3)
@@ -613,12 +617,15 @@ class EarthHeat(PrecomputedHeatPower):
             # Collect individual MSIDs for use in calc_earth_vis()
             ephem_xyzs = [getattr(self, 'orbitephem0_{}'.format(x))
                           for x in ('x', 'y', 'z')]
+            solar_xyzs = [getattr(self, 'solarephem0_{}'.format(x))
+                          for x in ('x', 'y', 'z')]
             aoattqt_1234s = [getattr(self, 'aoattqt{}'.format(x))
                              for x in range(1, 5)]
             # Note: the copy() here is so that the array becomes contiguous in
             # memory and allows numba to run faster (and avoids NumbaPerformanceWarning:
             # np.dot() is faster on contiguous arrays).
             ephems = np.array([x.dvals for x in ephem_xyzs]).transpose().copy()
+            solars = np.array([x.dvals for x in solar_xyzs]).transpose().copy()
             q_atts = np.array([x.dvals for x in aoattqt_1234s]).transpose()
 
             # Q_atts can have occasional bad values, maybe because the
@@ -639,6 +646,11 @@ class EarthHeat(PrecomputedHeatPower):
                 self.calc_earth_vis_from_grid(ephems, q_atts)
             else:
                 self.calc_earth_vis_from_taco(ephems, q_atts)
+
+            cos = np.sum(ephems*solars, axis=1)
+            es = np.sum(ephems*ephems, axis=1)*np.sum(solars*solars, axis=1)
+            cos /= np.sqrt(es)
+            self._dvals *= 0.5*(1.0+cos)
 
             self.put_cache()
 

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -659,9 +659,9 @@ class EarthHeat(PrecomputedHeatPower):
             # Earth's surface that is illuminated by the Sun. 
             solar_xyzs = [getattr(self, 'solarephem0_{}'.format(x))
                           for x in ('x', 'y', 'z')]
-            
-            if set(solar_xyzs) != {None}:
-                
+
+            if not None in solar_xyzs:
+
                 solars = np.array([x.dvals for x in solar_xyzs]).transpose().copy()
 
                 cos = np.sum(ephems*solars, axis=1)

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -656,9 +656,8 @@ class EarthHeat(PrecomputedHeatPower):
 
             # This next bit optionally checks to see if the solar ephemeris
             # was passed in, and if it was it computes the fraction of the
-            # Earth's surface that is illuminated by the Sun. 
-            solar_xyzs = [getattr(self, 'solarephem0_{}'.format(x))
-                          for x in ('x', 'y', 'z')]
+            # Earth's surface that is illuminated by the Sun.
+            solar_xyzs = [getattr(self, f'solarephem0_{x}') for x in 'xyz']
 
             if not None in solar_xyzs:
 

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -546,7 +546,7 @@ class EarthHeat(PrecomputedHeatPower):
                  orbitephem0_x, orbitephem0_y, orbitephem0_z,
                  aoattqt1, aoattqt2, aoattqt3, aoattqt4,
                  solarephem0_x=None, solarephem0_y=None, 
-                 solarephem0_z=None, k=1.0, k2=1.0):
+                 solarephem0_z=None, k=1.0, k2=None):
         ModelComponent.__init__(self, model)
         self.node = self.model.get_comp(node)
         self.orbitephem0_x = self.model.get_comp(orbitephem0_x)
@@ -572,7 +572,8 @@ class EarthHeat(PrecomputedHeatPower):
                                        for ax in "xyz"])
         self.n_mvals = 1
         self.add_par('k', k, min=0.0, max=2.0)
-        self.add_par('k2', k2, min=0.0, max=2.0)
+        if k2 is not None:
+            self.add_par('k2', k2, min=0.0, max=2.0)
         self.earth_phase = 1.0
 
     def calc_earth_vis_from_grid(self, ephems, q_atts):

--- a/xija/component/heat.py
+++ b/xija/component/heat.py
@@ -666,7 +666,8 @@ class EarthHeat(PrecomputedHeatPower):
                 cos = np.sum(ephems*solars, axis=1)
                 es = np.sum(ephems*ephems, axis=1)*np.sum(solars*solars, axis=1)
                 cos /= np.sqrt(es)
-                self._dvals *= 0.5*(1.0+cos)
+                self.earth_phase = 0.5*(1.0+cos)
+                self._dvals *= self.earth_phase
 
             self.put_cache()
 
@@ -717,6 +718,17 @@ class EarthHeat(PrecomputedHeatPower):
                           self.mvals_i,  # mvals with precomputed heat input
                           )
         self.tmal_floats = ()
+
+    def plot_earth_phase__time(self, fig, ax):
+        lines = ax.get_lines()
+        if not lines:
+            plot_cxctime(self.model.times, self.earth_phase, ls='-',
+                         color='#386cb0', fig=fig, ax=ax)
+            ax.grid()
+            ax.set_title('Earth Phase')
+            ax.set_ylabel('Earth Phase')
+        else:
+            lines[0].set_data(self.model_plotdate, self.dvals)
 
     def plot_data__time(self, fig, ax):
         lines = ax.get_lines()


### PR DESCRIPTION
## Description

NOTE: The PR is finished but there is no expected hurry to merge it since I anticipate it will generate some discussion. 

This PR allows the heating on the ACIS FP from the earthshine into the ACIS radiator to depend on the Earth phase. The existing code assumes that the relevant earthshine is in the infrared, which should to zeroth order be the same regardless if the Earth is illuminated or not by the Sun. This code is an experimental feature to test the hypothesis that the model for the effect of earthshine on the temperature could be improved if we accounted for the Earth phase. 

This PR adds this capability by using the solar ephemeris along with the spacecraft ephemeris to compute the fraction of the  Earth which is illuminated by the Sun. It is currently an optional calculation through the use of kwargs. Note that this is a simple calculation which assumes that the ACIS radiator can see the whole Earth. 

This calculation improves the fit of the ACIS FP thermal model at high temperatures during radzones, which was demonstrated [at the TWG on 3/3/22](https://occweb.cfa.harvard.edu/twiki/bin/view/ThermalWG/MeetingNotes2022x03x03).

## Interface impacts

If the Earth phase factor is not included, the same model results are obtained as with the previous xija version.

## Testing

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
### Functional tests

Models with and without the Earth phase factor were checked to ensure they ran as expected.
