### PR TITLE
Fix instabilities in xija_gui_fit, add ability to adjust error limits in histogram plots

### DIFF
--- a/xija/gui_fit/app.py
+++ b/xija/gui_fit/app.py
@@ -89,14 +89,12 @@ class FormattedTelemData:
         return val
 
 
-class FiltersWindow(QtWidgets.QMainWindow):
+class FiltersWindow(QtWidgets.QWidget):
     def __init__(self, model, main_window):
         super(FiltersWindow, self).__init__()
         self.model = model
         self.mw = main_window
         self.setWindowTitle("Filters")
-        wid = QtWidgets.QWidget(self)
-        self.setCentralWidget(wid)
 
         header_font = QtGui.QFont()
         header_font.setBold(True)
@@ -152,7 +150,7 @@ class FiltersWindow(QtWidgets.QMainWindow):
         self.box.addStretch(1)
         self.box.addLayout(close)
 
-        wid.setLayout(self.box)
+        self.setLayout(self.box)
         self.setGeometry(0, 0, 400, 400)
 
     def add_ignore(self):
@@ -207,18 +205,16 @@ class FiltersWindow(QtWidgets.QMainWindow):
         self.close()
 
 
-class WriteTableWindow(QtWidgets.QMainWindow):
+class WriteTableWindow(QtWidgets.QWidget):
     def __init__(self, model, main_window):
         super(WriteTableWindow, self).__init__()
         self.model = model
         self.mw = main_window
         self.setWindowTitle("Write Table")
-        wid = QtWidgets.QWidget(self)
         self.box = QtWidgets.QVBoxLayout()
-        wid.setLayout(self.box)
+        self.setLayout(self.box)
         self.setGeometry(0, 0, 200, 600)
         self.scroll = QtWidgets.QScrollArea()
-        self.setCentralWidget(wid)
 
         self.last_filename = ""
 
@@ -355,15 +351,13 @@ class WriteTableWindow(QtWidgets.QMainWindow):
                 msg.exec_()
 
 
-class ModelInfoWindow(QtWidgets.QMainWindow):
+class ModelInfoWindow(QtWidgets.QWidget):
     def __init__(self, model, main_window):
         super(ModelInfoWindow, self).__init__()
         self.model = model
         self.setWindowTitle("Model Info")
-        wid = QtWidgets.QWidget(self)
-        self.setCentralWidget(wid)
         self.box = QtWidgets.QVBoxLayout()
-        wid.setLayout(self.box)
+        self.setLayout(self.box)
         self.setGeometry(0, 0, 300, 200)
 
         self.main_window = main_window
@@ -427,15 +421,13 @@ class ModelInfoWindow(QtWidgets.QMainWindow):
         self.main_window.model_info_window = None
 
 
-class LineDataWindow(QtWidgets.QMainWindow):
+class LineDataWindow(QtWidgets.QWidget):
     def __init__(self, model, main_window, plots_box):
         super(LineDataWindow, self).__init__()
         self.model = model
         self.setWindowTitle("Line Data")
-        wid = QtWidgets.QWidget(self)
-        self.setCentralWidget(wid)
         self.box = QtWidgets.QVBoxLayout()
-        wid.setLayout(self.box)
+        self.setLayout(self.box)
         self.setGeometry(0, 0, 350, 600)
 
         self.plots_box = plots_box

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -494,16 +494,16 @@ class HistogramWindow(QtWidgets.QWidget):
         else:
             self.plot_dict["q01_text"] = self.ax2.text(
                 xpos_q01, ystart, '1% Quantile', 
-                ha="right", va="center", rotation=90)
+                ha="right", va="center", rotation=90, clip_on=True)
             self.plot_dict["q99_text"] = self.ax2.text(
                 xpos_q99, ystart, '99% Quantile', 
-                ha="left", va="center", rotation=90)
+                ha="left", va="center", rotation=90, clip_on=True)
             self.plot_dict["min_text"] = self.ax2.text(
                 xpos_min, ystart, 'Minimum Error', 
-                ha="right", va="center", rotation=90)
+                ha="right", va="center", rotation=90, clip_on=True)
             self.plot_dict["max_text"] = self.ax2.text(
                 xpos_max, ystart, 'Maximum Error', 
-                ha="left", va="center", rotation=90)
+                ha="left", va="center", rotation=90, clip_on=True)
 
         self.canvas.draw_idle()
 

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -8,7 +8,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
-
+from matplotlib.figure import Figure
 
 from xija.limits import get_limit_color
 from cheta.units import F_to_C
@@ -211,7 +211,7 @@ class HistogramWindow(QtWidgets.QWidget):
         self.fmt1_masked = False
         self.show_limits = False
 
-        self.fig = plt.figure()
+        self.fig = Figure()
 
         canvas = FigureCanvas(self.fig)
         toolbar = NavigationToolbar(canvas, parent=None)
@@ -504,7 +504,7 @@ class PlotBox(QtWidgets.QVBoxLayout):
         self.comp_name = comp_name
         self.plot_name = plot_name
 
-        self.fig = plt.figure()
+        self.fig = Figure()
         canvas = FigureCanvas(self.fig)
         toolbar = NavigationToolbar(canvas, parent=None)
         delete_plot_button = QtWidgets.QPushButton('Delete')

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -288,8 +288,10 @@ class HistogramWindow(QtWidgets.QWidget):
         self.ax1 = self.fig.add_subplot(1, 2, 1)
         self.ax2 = self.fig.add_subplot(1, 2, 2)
         self.plot_dict = {}
+        self.rz_mask
+        self.fmt1_mask
         self.make_plots()
-
+        
     @property
     def errorlimits(self):
         return self._errorlimits
@@ -576,6 +578,18 @@ class PlotBox(QtWidgets.QVBoxLayout):
             self.ly.set_xdata(self.plots_box.xline)
             self.canvas.draw_idle()
 
+    _rz_times = None
+    
+    @property
+    def rz_times(self):
+        if self._rz_times is None:
+            self._rz_times = []
+            rad_zones = get_radzones(self.plots_box.model)
+            for rz in rad_zones:
+                t0, t1 = cxctime2plotdate([rz.tstart, rz.tstop])
+                self._rz_times.append((t0, t1))
+        return self._rz_times
+
     def add_annotation(self, atype):
         if atype == "limits" and self.comp_name in self.plots_box.model.limits:
             limits = self.plots_box.model.limits[self.comp_name]
@@ -584,10 +598,8 @@ class PlotBox(QtWidgets.QVBoxLayout):
             elif "data__time" in self.plot_name:
                 self.limits = annotate_limits(limits, self.ax, dir='h')
         elif atype == "radzones" and self.plot_method.endswith("time"):
-            rad_zones = get_radzones(self.plots_box.model)
             self.rzlines = []
-            for rz in rad_zones:
-                t0, t1 = cxctime2plotdate([rz.tstart, rz.tstop])
+            for t0, t1 in self.rz_times:
                 self.rzlines += [
                     self.ax.axvline(t0, color='g', ls='--'),
                     self.ax.axvline(t1, color='g', ls='--')

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -579,7 +579,7 @@ class PlotBox(QtWidgets.QVBoxLayout):
             self.canvas.draw_idle()
 
     _rz_times = None
-    
+
     @property
     def rz_times(self):
         if self._rz_times is None:
@@ -664,7 +664,6 @@ class PlotsBox(QtWidgets.QVBoxLayout):
     def __init__(self, model, main_window):
         super(QtWidgets.QVBoxLayout, self).__init__()
         self.main_window = main_window
-        self.sharex = {}        # Shared x-axes keyed by x-axis type
         self.model = model
         self.xline = 0.5*np.sum(cxctime2plotdate([self.model.tstart,
                                                   self.model.tstop]))
@@ -672,7 +671,7 @@ class PlotsBox(QtWidgets.QVBoxLayout):
         self.plot_boxes = []
         self.plot_names = []
 
-        # Set up a default axis that will the scaling reference
+        # Set up a default axis that will act as the scaling reference
         self.default_fig, self.default_ax = plt.subplots()
         plot_cxctime(self.model.times, np.ones_like(self.model.times), 
                      fig=self.default_fig, ax=self.default_ax)
@@ -698,10 +697,10 @@ class PlotsBox(QtWidgets.QVBoxLayout):
         self.update_plot_boxes()
         # This is a hack to get the axes to appear correctly
         # on the rest of the plots after deleting one, somehow
-        # related to clearing the figure above 
+        # related to clearing the figure above
         for pb in self.plot_boxes:
             pb.ax.set_xlim()
-            
+
     def update_plots(self):
         mw = self.main_window
         mw.cbp.update_status.setText(' BUSY... ')


### PR DESCRIPTION
## Description

`xija_gui_fit` occasionally exhibits random crashes, especially when one is attempting to make new plots or pan/zoom within existing plots. This appears to be due to race conditions where an instruction to change a plot is made to a plot object that no longer exists. 

Along with https://github.com/sot/Ska.Matplotlib/pull/25, this PR seeks to avoid these crashes by doing the following:

* Avoid creating and re-creating `Figure` objects as much as possible, instead save the `Figure` object and update its data
* Add a short delay before updating plots after adding limit lines
* Caching rad zone times so they don't need to be created the first time you plot them
* General cleanup and simplification of code

This PR also adds the ability to manually specify the error limits in histogram plots, see the new input boxes in the lower-right of this image:

<img width="998" alt="image" src="https://user-images.githubusercontent.com/1914976/179283253-740f2300-fe80-4f3e-8298-51618d7bb919.png">

This allows more control over the histogram plots to make them more reproducible. 

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

* Open up `xija_gui_fit`, fit a model, create plots, zoom in and out, pan, re-fit, etc. to see if one gets a crash--no crashes occurred
* Check that changing the error plot limits update plots as desired