### PR TITLE
Avoid crashes in plotting, do not plot residuals of mask or bad times

### DIFF
--- a/xija/component/base.py
+++ b/xija/component/base.py
@@ -300,6 +300,8 @@ class Node(TelemData):
         resids = self.resids
         if self.mask:
             resids[~self.mask.mask] = np.nan
+        for i0, i1 in self.model.mask_times_indices:
+            resids[i0:i1] = np.nan
 
         if not lines:
             plot_cxctime(self.model.times, resids, ls='-', color='#386cb0', fig=fig, ax=ax)
@@ -312,12 +314,16 @@ class Node(TelemData):
             ax.set_ylabel('Temperature (%s)' % self.units)
         else:
             lines[0].set_ydata(resids)
+            ax.relim()
+            ax.autoscale()
 
     def plot_resid__data(self, fig, ax):
         lines = ax.get_lines()
         resids = self.resids
         if self.mask:
             resids[~self.mask.mask] = np.nan
+        for i0, i1 in self.model.mask_times_indices:
+            resids[i0:i1] = np.nan
 
         if not lines:
             ax.plot(self.dvals + self.randx, resids, 'o',
@@ -328,6 +334,8 @@ class Node(TelemData):
             ax.set_ylabel('Temperature (%s)' % self.units)
         else:
             lines[0].set_ydata(resids)
+            ax.relim()
+            ax.autoscale()
 
 
 class Coupling(ModelComponent):

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -284,7 +284,6 @@ class HistogramWindow(QtWidgets.QWidget):
         self.max_limit = -1000
         self.min_limit = 1000
 
-        self.canvas = canvas
         self.ax1 = self.fig.add_subplot(1, 2, 1)
         self.ax2 = self.fig.add_subplot(1, 2, 2)
         self.plot_dict = {}
@@ -505,7 +504,8 @@ class HistogramWindow(QtWidgets.QWidget):
                 xpos_max, ystart, 'Maximum Error', 
                 ha="left", va="center", rotation=90, clip_on=True)
 
-        self.canvas.draw_idle()
+        self.fig.canvas.draw_idle()
+        self.fig.canvas.flush_events()
 
 
 class PlotBox(QtWidgets.QVBoxLayout):
@@ -658,6 +658,7 @@ class PlotBox(QtWidgets.QVBoxLayout):
                 self.add_annotation("limits")
         self.fig.canvas.draw_idle()
         self.fig.canvas.flush_events()
+
 
 class PlotsBox(QtWidgets.QVBoxLayout):
     def __init__(self, model, main_window):

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -266,7 +266,7 @@ class HistogramWindow(QtWidgets.QWidget):
         self.emin_entry = QtWidgets.QLineEdit()
         self.emin_entry.setText(f"{self.errorlimits[0]}")
         self.emin_entry.returnPressed.connect(self.emin_edited)
-        
+
         self.emax_entry = QtWidgets.QLineEdit()
         self.emax_entry.setText(f"{self.errorlimits[1]}")
         self.emax_entry.returnPressed.connect(self.emax_edited)
@@ -291,11 +291,11 @@ class HistogramWindow(QtWidgets.QWidget):
         self.rz_mask
         self.fmt1_mask
         self.make_plots()
-        
+
     @property
     def errorlimits(self):
         return self._errorlimits
-    
+
     @errorlimits.setter
     def errorlimits(self, lims):
         self._errorlimits = lims
@@ -390,7 +390,7 @@ class HistogramWindow(QtWidgets.QWidget):
             mask &= self.rz_mask
         if self.fmt1_masked:
             mask &= self.fmt1_mask
-        for i0, i1 in self.model.bad_times_indices:
+        for i0, i1 in self.model.mask_times_indices:
             mask[i0:i1] = False
         resids = self.comp.resids[mask]
         dvals = self.comp.dvals[mask]

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -541,11 +541,10 @@ class PlotBox(QtWidgets.QVBoxLayout):
             self.ax = self.fig.add_subplot(111, sharex=plots_box.default_ax)
             self.ax.autoscale(enable=False, axis='x')
 
-        self.canvas = canvas
         self.plots_box = plots_box
         self.main_window = self.plots_box.main_window
-        self.selecter = self.canvas.mpl_connect("button_press_event", self.select)
-        self.releaser = self.canvas.mpl_connect("button_release_event", self.release)
+        self.selecter = self.fig.canvas.mpl_connect("button_press_event", self.select)
+        self.releaser = self.fig.canvas.mpl_connect("button_release_event", self.release)
 
         self.ly = None
         self.limits = None
@@ -556,7 +555,7 @@ class PlotBox(QtWidgets.QVBoxLayout):
         grab = event.inaxes and self.main_window.show_line and \
                not self.ax.get_navigate_mode()
         if grab:
-            self.mover = self.canvas.mpl_connect('motion_notify_event', self.on_mouse_move)
+            self.mover = self.fig.canvas.mpl_connect('motion_notify_event', self.on_mouse_move)
             self.plots_box.xline = event.xdata
             self.plots_box.update_xline()
         else:
@@ -571,12 +570,12 @@ class PlotBox(QtWidgets.QVBoxLayout):
 
     def release(self, event):
         if hasattr(self, "mover"):
-            self.canvas.mpl_disconnect(self.mover)
+            self.fig.canvas.mpl_disconnect(self.mover)
 
     def update_xline(self):
         if self.plot_name.endswith("time") and self.ly is not None:
             self.ly.set_xdata(self.plots_box.xline)
-            self.canvas.draw_idle()
+            self.fig.canvas.draw_idle()
 
     _rz_times = None
 
@@ -657,8 +656,8 @@ class PlotBox(QtWidgets.QVBoxLayout):
                 self.add_annotation("line")
             if mw.show_limits:
                 self.add_annotation("limits")
-        self.canvas.draw_idle()
-
+        self.fig.canvas.draw_idle()
+        self.fig.canvas.flush_events()
 
 class PlotsBox(QtWidgets.QVBoxLayout):
     def __init__(self, model, main_window):


### PR DESCRIPTION
## Description

For models which execute very quickly, it is sometimes the case that during fitting a race condition of sorts is encountered when a plot that is being updated and a reference to the canvas object associated with the plot is lost (see Issue #126).

Unfortunately, the cause for this is still unknown. I was able to fix this problem by 1) Removing unnecessary references to the `canvas` object I was keeping around and also calling `canvas.flush_events` after every update.

This PR also adds some logic that affects the `resid__data` and histogram/dashboard plots in `xija_gui_fit` by masking out data that is under a "bad time" or a "mask time". The residuals are set to zero in such cases, but because of that they still appear in the plot and can give default plot limits that are unhelpful. We copy the residual data before plotting and set the masked data to `NaN` here. 

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #126 


## Testing
<!-- If relevant describe any special setup for testing. -->

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Fitted the 1DPAMZT model over several iterations, fit the WIP HRC model which was crashing previously, crashes no longer occur.