### PR TITLE
Fix problem of dropping bad_times in spec file

### DIFF
--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -49,7 +49,7 @@ def calcquantiles(errors):
     error :
         model errors (telemetry - model)
     errors :
-        
+
 
     Returns
     -------
@@ -76,7 +76,7 @@ def calcquantstats(Ttelem, error):
     -------
     type
         coordinates for error quantile line
-        
+
         This is used for the telemetry vs. error plot (axis 3).
 
     """
@@ -109,7 +109,7 @@ def getQuantPlotPoints(quantstats, quantile):
     -------
     type
         coordinates for error quantile line
-        
+
         This is used to calculate the quantile lines plotted on the telemetry vs. error plot (axis 3)
         enclosing the data (i.e. the 1 and 99 percentile lines).
 
@@ -139,7 +139,7 @@ def clearLayout(layout):
     Parameters
     ----------
     layout :
-        
+
 
     Returns
     -------
@@ -163,16 +163,16 @@ def annotate_limits(limits, ax, dir='h'):
     ----------
     limits : dict
         Dictionary of limits obtained from the model
-        specification file. 
+        specification file.
     ax : Matplotlib Axes object
-        The Axes object on which the line is to be 
-        written. 
+        The Axes object on which the line is to be
+        written.
     dir : str, optional
         The direction of the line, "h" for horizontal
         or "v" for vertical. Default: "h"
 
     Returns
-    ------- 
+    -------
     list
         A list of matplotlib.lines.Line2D objects
     """
@@ -442,16 +442,16 @@ class HistogramWindow(QtWidgets.QWidget):
             self.plot_dict["step"] = self.ax2.step(
                 bin_mid, hist, '#386cb0', where='mid')[0]
             self.plot_dict["q01"] = self.ax2.axvline(
-                stats['q01'], color='k', linestyle='--', 
+                stats['q01'], color='k', linestyle='--',
                 linewidth=1.5, alpha=1)
             self.plot_dict["q99"] = self.ax2.axvline(
-                stats['q99'], color='k', linestyle='--', 
+                stats['q99'], color='k', linestyle='--',
                 linewidth=1.5, alpha=1)
             self.plot_dict["min_hist"] = self.ax2.axvline(
-                min_resid, color='k', linestyle='--', 
+                min_resid, color='k', linestyle='--',
                 linewidth=1.5, alpha=1)
             self.plot_dict["max_hist"] = self.ax2.axvline(
-                max_resid, color='k', linestyle='--', 
+                max_resid, color='k', linestyle='--',
                 linewidth=1.5, alpha=1)
         else:
             self.plot_dict['resids'].set_data(resids, dvalsr)
@@ -492,16 +492,16 @@ class HistogramWindow(QtWidgets.QWidget):
             self.plot_dict["max_text"].set_position((xpos_max, ystart))
         else:
             self.plot_dict["q01_text"] = self.ax2.text(
-                xpos_q01, ystart, '1% Quantile', 
+                xpos_q01, ystart, '1% Quantile',
                 ha="right", va="center", rotation=90, clip_on=True)
             self.plot_dict["q99_text"] = self.ax2.text(
-                xpos_q99, ystart, '99% Quantile', 
+                xpos_q99, ystart, '99% Quantile',
                 ha="left", va="center", rotation=90, clip_on=True)
             self.plot_dict["min_text"] = self.ax2.text(
-                xpos_min, ystart, 'Minimum Error', 
+                xpos_min, ystart, 'Minimum Error',
                 ha="right", va="center", rotation=90, clip_on=True)
             self.plot_dict["max_text"] = self.ax2.text(
-                xpos_max, ystart, 'Maximum Error', 
+                xpos_max, ystart, 'Maximum Error',
                 ha="left", va="center", rotation=90, clip_on=True)
 
         self.fig.canvas.draw_idle()
@@ -535,7 +535,7 @@ class PlotBox(QtWidgets.QVBoxLayout):
 
         # Add shared x-axes for plots with time on the x-axis
         xaxis = plot_method.split('__')
-        if len(xaxis) == 1 or not plot_method.endswith("time"): 
+        if len(xaxis) == 1 or not plot_method.endswith("time"):
             self.ax = self.fig.add_subplot(111)
         else:
             self.ax = self.fig.add_subplot(111, sharex=plots_box.default_ax)
@@ -631,10 +631,10 @@ class PlotBox(QtWidgets.QVBoxLayout):
             self.ignores.append(fill)
 
     def show_fills(self):
-        if len(self.plots_box.model.mask_time_secs) == 0:
-            return
-        for i, t in enumerate(self.plots_box.model.mask_time_secs):
-            self.add_fill(t[0], t[1], self.plots_box.model.mask_times_bad[i])
+        model = self.plots_box.model
+        for (i0, i1), bad in zip(model.mask_times_indices, model.mask_times_bad):
+            t0, t1 = model.times[i0], model.times[i1]
+            self.add_fill(t0, t1, bad)
 
     def remove_ignores(self):
         [fill.remove() for fill in self.ignores]
@@ -673,7 +673,7 @@ class PlotsBox(QtWidgets.QVBoxLayout):
 
         # Set up a default axis that will act as the scaling reference
         self.default_fig, self.default_ax = plt.subplots()
-        plot_cxctime(self.model.times, np.ones_like(self.model.times), 
+        plot_cxctime(self.model.times, np.ones_like(self.model.times),
                      fig=self.default_fig, ax=self.default_ax)
 
     def add_plot_box(self, plot_name):

--- a/xija/model.py
+++ b/xija/model.py
@@ -67,7 +67,7 @@ def _get_bad_times_indices(
 
     :returns: bad_times_indices: List[List[int, int]]
     """
-    if len(bad_times_in) == 0:
+    if bad_times_in is None or len(bad_times_in) == 0:
         return []
 
     bad_times: np.ndarray = np.array(bad_times_in)
@@ -179,7 +179,7 @@ class XijaModel(object):
         self.rk4 = rk4
         self.limits = limits
 
-        self.bad_times = [] if (model_spec is None) else model_spec.get('bad_times')
+        self.bad_times = None if (model_spec is None) else model_spec.get('bad_times')
         self.bad_times_indices = _get_bad_times_indices(
             self.times, self.datestart, self.datestop, self.bad_times
         )

--- a/xija/tests/test_models.py
+++ b/xija/tests/test_models.py
@@ -371,9 +371,7 @@ def test_bad_times():
     mdl = xija.XijaModel(
         'test', '2022:083:22:30:00', '2022:084:04:00:00', model_spec=spec1,
     )
-    exp = [['2022:083:22:02:09.949', '2022:083:22:40:58.749'],
-           ['2022:083:23:03:56.349', '2022:084:03:45:28.350']]
-    assert mdl.bad_times == exp
+    assert len(mdl.bad_times) == len(spec1["bad_times"])
     assert mdl.bad_times_indices == [[0, 2], [6, 58]]
     assert 58 < mdl.n_times
 
@@ -382,21 +380,19 @@ def test_bad_times():
         'test', '2022:084:00:00:00', '2022:084:01:00:00', model_spec=spec1,
     )
     exp = [['2022:083:23:03:56.349', '2022:084:03:45:28.350']]
-    assert mdl.bad_times == exp
+    assert mdl.bad_times == spec1["bad_times"]
     assert mdl.bad_times_indices == [[0, len(mdl.times)]]
 
     # Within one bad time interval
     mdl = xija.XijaModel(
         'test', '2022:084:00:00:00', '2022:084:01:00:00', model_spec=spec1,
     )
-    exp = [['2022:083:23:03:56.349', '2022:084:03:45:28.350']]
-    assert mdl.bad_times == exp
+    assert mdl.bad_times == spec1["bad_times"]
     assert mdl.bad_times_indices == [[0, len(mdl.times)]]
 
     # Within no bad time interval
     mdl = xija.XijaModel(
         'test', '2022:084:04:00:00', '2022:084:07:00:00', model_spec=spec1,
     )
-    exp = []
-    assert mdl.bad_times == exp
+    assert mdl.bad_times == spec1["bad_times"]
     assert mdl.bad_times_indices == []


### PR DESCRIPTION
## Description

This fixes the issue noted on slack that after #123, any bad times in a model spec file that were not covered by the fitting range in `xija_gui_fit` would be dropped from the spec file.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

I made a copy of the flight `aca_spec.json` file and added a new bad time interval (not strictly necessary but I did it):
```
        [
            "2020:165:14:10:00",
            "2020:170:00:00:00"
        ]
```
Then using both `master` branch and this branch, I did:
```
python -m xija.gui_fit.app aca_spec.json --stop 2020:190 --days 60
```
In both cases:
- Confirm seeing the two expected bad time intervals marked in light blue on the plot.
- Confirm that masked values are hidden in the residual plot.
- Freeze all parameters and thaw a couple of solar heat P parameters
- Fit and confirm things look OK with no obvious influence of the bad time intervals.
- Save spec file as JSON

Using the `master` branch I saw that all the saved bad times outside of the fit range were missing.
Using this branch I saw that the saved bad times matched exactly the original bad times.
