### PR TITLE
Refactor get_model_spec to use ska_helpers.chandra_models

### DIFF
--- a/xija/tests/test_get_model_spec.py
+++ b/xija/tests/test_get_model_spec.py
@@ -55,7 +55,7 @@ def test_get_model_file_fail():
     with pytest.raises(ValueError, match="no models matched xxxyyyzzz"):
         get_xija_model_spec("xxxyyyzzz")
 
-    with pytest.raises(git.GitCommandError, match="does not exist"):
+    with pytest.raises(git.exc.NoSuchPathError):
         get_xija_model_spec("aca", repo_path="__NOT_A_DIRECTORY__")
 
 


### PR DESCRIPTION
## Description

This refactors the `get_model_spec` module to use `ska_helpers.chandra_models`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None, this is expected to be API compatible with the previous version.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
