### PR TITLE
Use cheta not Ska.engarchive

### DIFF
--- a/models/acisfp/calc_model.py
+++ b/models/acisfp/calc_model.py
@@ -8,8 +8,8 @@ values.
 """
 
 import xija
-import Ska.engarchive.fetch_eng as fetch_eng
-from Ska.Matplotlib import plot_cxctime
+from cheta import fetch_eng
+from ska_matplotlib import plot_cxctime
 
 start = '2012:001'
 stop = '2012:005'

--- a/xija/model.py
+++ b/xija/model.py
@@ -366,12 +366,12 @@ class XijaModel(object):
         datestop = DateTime(self.tstop + tpad).date
         logger.info("Fetching msid: %s over %s to %s" % (msid, datestart, datestop))
         try:
-            import Ska.engarchive.fetch_sci as fetch
+            import cheta.fetch_sci as fetch
 
             tlm = fetch.MSID(msid, datestart, datestop, stat="5min")
             tlm.filter_bad_times()
         except ImportError:
-            raise ValueError("Ska.engarchive.fetch not available")
+            raise ValueError("cheta.fetch not available")
         if tlm.times[0] > self.tstart or tlm.times[-1] < self.tstop:
             raise ValueError(
                 "Fetched telemetry does not span model start and "


### PR DESCRIPTION
## Description

Use `cheta` instead of `Ska.engarchive`. This fixes the test warning noted in https://github.com/sot/cheta/pull/252.

Also use `ska_matplotlib` instead of `Ska.Matplotlib`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Successfully ran `models/acisfp/calc_model.py` to check imports.
