### PR TITLE
Change the ACIS-I limit line color to dark orange

### DIFF
--- a/xija/limits.py
+++ b/xija/limits.py
@@ -35,7 +35,7 @@ def get_limit_spec(limit):
 
 
 LIMIT_COLORS = {
-    "*.acisi": "blue",
+    "*.acisi": "darkorange",
     "*.aciss": "purple",
     "*.aciss_hot": "red",
     "*.cold_ecs": "dodgerblue",


### PR DESCRIPTION
## Description
This PR only changes the ACIS-I limit line for the FP temperature model to dark orange. This will make the plots in an upcoming version of `acis_thermal_check` easier to read. 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->
Not needed

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
