### PR TITLE
Change np.float to float

### DIFF
--- a/xija/component/heat/solar.py
+++ b/xija/component/heat/solar.py
@@ -612,7 +612,7 @@ class SimZDepSolarHeat(PrecomputedHeatPower):
         self.dPs = (
             np.zeros_like(self.dP_pitches)
             if dPs is None
-            else np.array(dPs, dtype=np.float)
+            else np.array(dPs, dtype=float)
         )
         for i, instr_name in enumerate(self.instr_names):
             for j, pitch in enumerate(self.P_pitches):


### PR DESCRIPTION
## Description

Convert an instance of `np.float` to `float`.

See: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. These deprecations are errors as of numpy 1.26. The code here is not covered in unit testing unfortunately.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2024.1rc4) ➜  xija git:(fix-np-float) pytest xija                 
================================================================ test session starts ================================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 43 items                                                                                                                                  

xija/tests/test_get_model_spec.py .......                                                                                                     [ 16%]
xija/tests/test_models.py ....................................                                                                                [100%]

================================================================ 43 passed in 37.04s ================================================================
(ska3-flight-2024.1rc4) ➜  xija git:(fix-np-float) git rev-parse HEAD                                                                            
34169ca4b834c6841c3ed98ada1c97455359d35d


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
