### PR TITLE
Minor interface improvements and fix bug writing Python spec file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 24.10.0
     hooks:
     - id: black
-      language_version: python3.10
+      language_version: python3.11
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
     - id: isort
       name: isort (python)
-      language_version: python3.10
+      language_version: python3.11

--- a/xija/gui_fit/app.py
+++ b/xija/gui_fit/app.py
@@ -1150,7 +1150,17 @@ class MainWindow:
 
 def get_options():
     parser = argparse.ArgumentParser()
-    parser.add_argument("filename", default="test_gui.json", help="Model file")
+    parser.add_argument(
+        "filename",
+        default="test_gui.json",
+        help="Model or file name: '*.json' is a local spec file, otherwise this is a "
+        "model name (e.g. 'acisfp_spec_matlab') that points to a like-named JSON spec "
+        "file in the Ska chandra_models repo.",
+    )
+    parser.add_argument(
+        "--model-version",
+        help="Model version for model from chandra_models",
+    )
     parser.add_argument(
         "--days",
         type=float,

--- a/xija/model.py
+++ b/xija/model.py
@@ -12,7 +12,7 @@ import os
 from collections import OrderedDict
 from io import StringIO
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import numpy as np
 import pyyaks.context as pyc
@@ -37,11 +37,6 @@ files = (
     else pyc.ContextDict("files", basedir=os.getcwd())
 )
 files.update(xija_files)
-
-if "debug" in globals():
-    from IPython.Debugger import Tracer
-
-    pdb_settrace = Tracer()
 
 logger = clogging.config_logger("xija", level=clogging.INFO)
 
@@ -263,7 +258,7 @@ class XijaModel(object):
         """
         try:
             inherit_spec = json.load(open(inherit_spec, "r"))
-        except:
+        except Exception:
             pass
 
         inherit_pars = {par["full_name"]: par for par in inherit_spec["pars"]}

--- a/xija/model.py
+++ b/xija/model.py
@@ -591,9 +591,16 @@ class XijaModel(object):
         out = StringIO()
         ms = self.model_spec
 
-        model_call = "model = xija.XijaModel({}, start={}, stop={}, dt={},\n"
-        model_call += "evolve_method={} rk4={}\n"
-
+        model_call = """\
+model = xija.XijaModel(
+  {},
+  start={},
+  stop={},
+  dt={},
+  evolve_method={},
+  rk4={},
+)
+"""
         print("import sys", file=out)
         print("import xija\n", file=out)
         print(

--- a/xija/tests/test_get_model_spec.py
+++ b/xija/tests/test_get_model_spec.py
@@ -52,7 +52,7 @@ def test_get_model_spec_aca_from_github():
 
 
 def test_get_model_file_fail():
-    with pytest.raises(ValueError, match="no models matched xxxyyyzzz"):
+    with pytest.raises(ValueError, match="no model spec files matched xxxyyyzzz"):
         get_xija_model_spec("xxxyyyzzz")
 
     with pytest.raises(git.exc.NoSuchPathError):


### PR DESCRIPTION
## Description

This makes it easier to run xija_gui_fit for model spec files taken from the Ska data `chandra_models` repo:
- Can specify a `--model-version` to pick a particular version.
- Previously names like `acisfp_spec_matlab` were not allowed because it automatically appended `_spec` to the model name. Now it tries both the original model name and one with `_spec` appended. Doing that appending was a mistake, but it is left there for back-compatibility.

In addition this fixes a bug when writing out the Python script that will generate a spec file.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2025.0rc2) ➜  xija git:(improved-model-spec-file) git rev-parse --short HEAD                            
2a67036
(ska3-flight-2025.0rc2) ➜  xija git:(improved-model-spec-file) pytest xija
===================================================== test session starts ======================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Volumes/git
configfile: pytest.ini
plugins: doctestplus-1.3.0, anyio-4.7.0, timeout-2.3.1
collected 44 items                                                                                                             

xija/tests/test_get_model_spec.py .......                                                                                [ 15%]
xija/tests/test_models.py .....................................                                                          [100%]

===================================================== 44 passed in 35.05s ======================================================
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

#### Application help showing new option:
```
(ska3-flight-2025.0rc2) ➜  xija git:(improved-model-spec-file) python -m xija.gui_fit.app --help
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
usage: app.py [-h] [--model-version MODEL_VERSION] [--days DAYS] [--stop STOP] [--maxiter MAXITER]
              [--fit-method FIT_METHOD] [--inherit-from INHERIT_FROM] [--set-data SET_DATA_EXPRS]
              [--quiet]
              filename

positional arguments:
  filename              Model or file name: '*.json' is a local spec file, otherwise this is a model
                        name (e.g. 'acisfp_spec_matlab') that points to a like-named JSON spec file in
                        the Ska chandra_models repo.

options:
  -h, --help            show this help message and exit
  --model-version MODEL_VERSION
                        Model version for model from chandra_models
  --days DAYS           Number of days in fit interval (default=90
  --stop STOP           Stop time of fit interval (default=model values)
  --maxiter MAXITER     Maximum number of fit iterations (default=1000)
  --fit-method FIT_METHOD
                        Sherpa fit method (simplex|moncar|levmar)
  --inherit-from INHERIT_FROM
                        Inherit par values from model spec file
  --set-data SET_DATA_EXPRS
                        Set data value as '<comp_name>=<value>'
  --quiet               Suppress screen output
```
#### Full model spec file name (acisfp_spec_matlab) with default (latest) version.
```
(ska3-flight-2025.0rc2) ➜  xija git:(improved-model-spec-file) python -m xija.gui_fit.app acisfp_spec_matlab
... sherpa warnings
Using model version 3.62 from chandra_models
... rest of outputs
# Brings up xija_gui_fit window as expected
```
#### Shortened model spec name (acisfp => acisfp_spec) with non-default version
```
(ska3-flight-2025.0rc2) ➜  xija git:(improved-model-spec-file) python -m xija.gui_fit.app acisfp --model-version=3.60 
... sherpa warnings
Using model version 3.60 from chandra_models
Fetching msid: fptemp_11 over 2025:002:23:34:30.816 to 2025:018:15:02:38.816
...
# Rest of output and normal fit window comes up
```
#### Save model to Python
First start xija_gui_fit with:
```
(ska3-flight-2025.0rc2) ➜  xija git:(improved-model-spec-file) python -m xija.gui_fit.app acisfp --model-version=3.60 
```
Then save the model as Python to `acisfp_spec_3.60.py`. Then run that file to remake the spec file. Previously this failed with a SyntaxError.
```
(ska3-flight-2025.0rc2) ➜  xija git:(improved-model-spec-file) python acisfp_spec_3.60.py acisfp_spec_3.60.json
(ska3-flight-2025.0rc2) ➜  xija git:(improved-model-spec-file) head -13 acisfp_spec_3.60.py                  
import sys
import xija

model = xija.XijaModel(
  'acisfp',
  start='2025:003:00:01:50.816',
  stop='2025:018:14:40:46.816',
  dt=328.0,
  evolve_method=2,
  rk4=0,
)
```
