### PR TITLE
Initialize ModelComponent pars_dict if needed.

### DIFF
--- a/xija/component/base.py
+++ b/xija/component/base.py
@@ -81,13 +81,21 @@ class ModelComponent(object):
         if attr == "trait_names":
             return []
 
-        if 'pars_dict' in self.__dict__ and attr in self.pars_dict:
+        # Ensure pars_dict is initialized before accessing it
+        if "pars_dict" not in self.__dict__:
+            super(ModelComponent, self).__setattr__("pars_dict", {})
+
+        if attr in self.pars_dict:
             return self.pars_dict[attr].val
         else:
             # This will raise the expected AttributeError exception
             return super(ModelComponent, self).__getattribute__(attr)
 
     def __setattr__(self, attr, val):
+        # Ensure pars_dict is initialized before accessing it
+        if "pars_dict" not in self.__dict__:
+            super(ModelComponent, self).__setattr__("pars_dict", {})
+
         if attr in self.pars_dict:
             self.pars_dict[attr].val = val
         else:

--- a/xija/component/base.py
+++ b/xija/component/base.py
@@ -81,7 +81,7 @@ class ModelComponent(object):
         if attr == "trait_names":
             return []
 
-        if attr in self.pars_dict:
+        if 'pars_dict' in self.__dict__ and attr in self.pars_dict:
             return self.pars_dict[attr].val
         else:
             # This will raise the expected AttributeError exception


### PR DESCRIPTION
## Description

Initialize ModelComponent pars_dict if needed.

Update the `__getattr__` and `__setattr__` to initialize the pars_dict if not already initialized by `__init__`.  I think this can happen in xija_gui_fit due to use of `multiprocessing` in Python 3.12.  

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes https://github.com/sot/skare3/issues/1485
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/jean/miniforge3/envs/2025.1rc1/lib/python3.12/multiprocessing/spawn.py", line 122, in spawn_main
    exitcode = _main(fd, parent_sentinel)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jean/miniforge3/envs/2025.1rc1/lib/python3.12/multiprocessing/spawn.py", line 132, in _main
    self = reduction.pickle.load(from_parent)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jean/git/xija/xija/component/base.py", line 84, in __getattr__
    if attr in self.pars_dict:
               ^^^^^^^^^^^^^^
  File "/Users/jean/git/xija/xija/component/base.py", line 84, in __getattr__
    if attr in self.pars_dict:
               ^^^^^^^^^^^^^^
  File "/Users/jean/git/xija/xija/component/base.py", line 84, in __getattr__
    if attr in self.pars_dict:
               ^^^^^^^^^^^^^^
  [Previous line repeated 994 more times]
RecursionError: maximum recursion depth exceeded
```
This RecursionError was seen on the skare3 2025.1rc2 candidate.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(2025.1rc1) flame:xija jean$ pytest xija
============================================================================================== test session starts ==============================================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 44 items                                                                                                                                                                                              

xija/tests/test_get_model_spec.py .......                                                                                                                                                                 [ 15%]
xija/tests/test_models.py .....................................                                                                                                                                           [100%]

=============================================================================================== warnings summary ================================================================================================
xija/xija/tests/test_models.py::test_dpa_real[True]
  /Users/jean/miniforge3/envs/2025.1rc1/lib/python3.12/site-packages/setuptools_scm/git.py:312: UserWarning: git archive did not support describe output
    warnings.warn("git archive did not support describe output")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================== 44 passed, 1 warning in 34.80s =========================================================================================
(2025.1rc1) flame:xija jean$ git rev-parse HEAD
c0c4af4772ae724546b34c628e78b55c0c68535b
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
`xija_gui_fit ~/ska/data/chandra_models/chandra_models/xija/acisfp/acisfp_spec_matlab.json `
plus "Fit" - causes xija_gui_fit to run a fit to completion instead of RecursionError.
