### PR TITLE
Fix intersphinx_mapping syntax

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -281,4 +281,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3/', None)}


### PR DESCRIPTION
## Description

Docs only fix to deal with 

```
ERROR: Invalid value `None` in intersphinx_mapping['http://docs.python.org/']. Expected a two-element tuple or list.
```
With this change "make html" worked for me.
