### PR TITLE
Improved implementation for pars_dict and pars attributes + pickle test

### DIFF
--- a/xija/component/base.py
+++ b/xija/component/base.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from functools import cached_property
+
 import numpy as np
 import six
 
@@ -45,15 +47,6 @@ class Param(dict):
 class ModelComponent(object):
     """Model component base class"""
 
-    def __new__(cls, *args, **kwargs):
-        instance = super(ModelComponent, cls).__new__(cls)
-        # This class overrides __setattr__ with a method that requires
-        # the `pars` and `pars_dict` attrs to be visible.  So do this
-        # with the super (object) method right away.
-        super(ModelComponent, instance).__setattr__("pars", [])
-        super(ModelComponent, instance).__setattr__("pars_dict", {})
-        return instance
-
     def __init__(self, model):
         self.model = model
         self.n_mvals = 0
@@ -61,8 +54,21 @@ class ModelComponent(object):
         self.data = None
         self.data_times = None
 
-    n_parvals = property(lambda self: len(self.parvals))
-    times = property(lambda self: self.model.times)
+    @cached_property
+    def pars(self):
+        return []
+
+    @cached_property
+    def pars_dict(self):
+        return {}
+
+    @property
+    def n_parvals(self):
+        return len(self.parvals)
+
+    @property
+    def times(self):
+        return self.model.times
 
     @property
     def model_plotdate(self):

--- a/xija/tests/test_models.py
+++ b/xija/tests/test_models.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
+import pickle
 import tempfile
 from pathlib import Path
 
@@ -55,17 +56,13 @@ def test_dpa_real(as_path):
     assert np.allclose(dpa.mvals, regr["mvals"])
 
 
-def test_pitch_clip():
+def test_pitch_clip_and_pickle():
     """Pitch in this time range goes from 48.62 to 158.41.  dpa_clip.json
     has been modified so the solarheat pitch range is from 55 .. 153.
     Make sure the model still runs with no interpolation error.
 
-    Parameters
-    ----------
-
-    Returns
-    -------
-
+    Also since there is a model available, test that the model can be pickled.
+    See https://chandramission.slack.com/archives/G01LN40AXPG/p1738153692023699.
     """
     mdl = ThermalModel(
         "dpa",
@@ -77,6 +74,12 @@ def test_pitch_clip():
 
     mdl.make()
     mdl.calc()
+
+    # Test model can be pickled and unpickled and that the comps have same names.
+    mdl_pkl = pickle.loads(pickle.dumps(mdl))
+    for comp, comp_pkl in zip(mdl.comp.values(), mdl_pkl.comp.values(), strict=True):
+        assert comp.name == comp_pkl.name
+        assert comp.pars_dict.keys() == comp_pkl.pars_dict.keys()
 
 
 def test_pitch_range_clip():


### PR DESCRIPTION
## Description

This improves on the fix from #142 using `cached_property` to define the `pars_dict` and `pars` properties with defaults as `{}` and `[]` respectively.

It also fixes poor coding style for a couple of properties.

This is not needed for Ska3 2025.1, it can go in a later release.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2025.0rc2) ➜  xija git:(recursion-redux) git rev-parse --short HEAD
39633c7
(ska3-flight-2025.0rc2) ➜  xija git:(recursion-redux) pytest xija
===================================================== test session starts ======================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Volumes/git
configfile: pytest.ini
plugins: doctestplus-1.3.0, anyio-4.7.0, timeout-2.3.1
collected 44 items                                                                                                             

xija/tests/test_get_model_spec.py .......                                                                                [ 15%]
xija/tests/test_models.py .....................................                                                          [100%]

===================================================== 44 passed in 34.85s ======================================================
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
```
(ska3-flight-2025.0rc2) ➜  xija git:(recursion-redux) python -m xija.gui_fit.app acisfp_spec_matlab --stop 2025:001
```
This worked as expected, in particular fitting succeeded.