### PR TITLE
Use full ephemeris data not 5min stat

### DIFF
--- a/xija/model.py
+++ b/xija/model.py
@@ -364,7 +364,12 @@ class XijaModel:
         datestop = DateTime(self.tstop + tpad).date
 
         logger.info("Fetching msid: %s over %s to %s" % (msid, datestart, datestop))
-        tlm = fetch.MSID(msid, datestart, datestop, stat="5min")
+
+        # Orbit and solar ephemeris MSIDs are already sampled at 5min, so don't use the
+        # 5min stat. This avoids an issue with the cheta sync mechanism where the 5min
+        # data lag behind by a week or two.
+        stat = None if msid.lower().startswith(("orbitephem", "solarephem")) else "5min"
+        tlm = fetch.MSID(msid, datestart, datestop, stat=stat)
         tlm.filter_bad_times()
 
         if tlm.times[0] > self.tstart or tlm.times[-1] < self.tstop:


### PR DESCRIPTION
## Description

This allows running models that depend on the solar / orbit ephemeris files up to the limit of other CXC telemetry on all machines (not just HEAD).

There is an issue with cheta sync where the ephemeris 5min stats can lag behind other telemetry. This impacts GRETA machines and laptops that keep up to date with `cheta_sync`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Models like the ACIS FP model which depend on the ephemeris will change slightly. See below for an example.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  xija git:(use-full-telem-for-orbitephem) git rev-parse --short HEAD                                                     
1066bcb
(ska3) ➜  xija git:(use-full-telem-for-orbitephem) pytest
====================================================== test session starts =======================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 44 items                                                                                                               

xija/tests/test_get_model_spec.py .......                                                                                  [ 15%]
xija/tests/test_models.py .....................................                                                            [100%]

====================================================== 44 passed in 37.49s =======================================================
```
Independent check of unit tests by Jean
- [x] OSX
```
(latest) flame:xija jean$ git rev-parse HEAD
1066bcb1f9097865622092af606ce0035fee87f8
(latest) flame:xija jean$ pytest
========================================================= test session starts ==========================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 45 items                                                                                                                     

xija/tests/test_get_model_spec.py .......                                                                                        [ 15%]
xija/tests/test_models.py ......................................                                                                 [100%]

=========================================================== warnings summary ===========================================================
xija/xija/tests/test_models.py::test_dpa_real[True]
  /Users/jean/miniforge3/envs/latest/lib/python3.12/site-packages/setuptools_scm/git.py:312: UserWarning: git archive did not support describe output
    warnings.warn("git archive did not support describe output")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 45 passed, 1 warning in 38.51
```

### Functional tests

#### Does it work
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
At this time, the cheta_sync ephem files go out through 2025:322. Without this PR, the following fails (`ValueError: Fetched telemetry does not span model start and stop times for orbitephem0_x`), but with the PR it runs as expected.
```
python -m xija.gui_fit.app acisfp  --stop=2025:324 --days=20
```

#### Model impact
For the ACIS FP model, here is a plot of the model difference between this PR and master.
<img width="575" height="420" alt="image" src="https://github.com/user-attachments/assets/df208518-b68d-4111-ba38-e82927953379" />
<img width="602" height="420" alt="image" src="https://github.com/user-attachments/assets/d01a6e84-bda4-468c-a93e-789abf448cf8" />


