### PR TITLE
Stop RuntimeError FigureCanvasQTAgg has been deleted

### DIFF
--- a/xija/gui_fit/app.py
+++ b/xija/gui_fit/app.py
@@ -23,7 +23,7 @@ from xija.component.base import Node, TelemData
 from xija.get_model_spec import get_xija_model_spec
 
 from .fitter import FitWorker, fit_logger
-from .plots import FitStatWindow, HistogramWindow, PlotsBox
+from .plots import FitStatWindow, HistogramWindow, PlotsPanel
 
 gui_config = {}
 
@@ -956,10 +956,10 @@ class MainLeftPanel(Panel):
     def __init__(self, model, main_window):
         Panel.__init__(self, orient="v")
         self.control_buttons_panel = ControlButtonsPanel(model)
-        self.plots_box = PlotsBox(model, main_window)
+        self.plots_panel = PlotsPanel(model, main_window)
+        self.plots_box = self.plots_panel.plots_box
         self.pack_start(self.control_buttons_panel)
-        # This specialized code is for the PlotsBox because we
-        # want it to be scrollable
+        # Make PlotsPanel scrollable
         self.scroll = QtWidgets.QScrollArea()
         self.scroll.setWidgetResizable(True)
         self.scroll.setSizePolicy(
@@ -968,12 +968,7 @@ class MainLeftPanel(Panel):
         self.scroll.setFrameShape(
             QtWidgets.QFrame.NoFrame
         )  # optional, just looks nicer
-        container = QtWidgets.QWidget()
-        container.setLayout(self.plots_box)
-        container.setSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred
-        )
-        self.scroll.setWidget(container)
+        self.scroll.setWidget(self.plots_panel)
         self.box.addWidget(self.scroll, 1)
 
 
@@ -1026,9 +1021,10 @@ class MainWindow:
 
         self.main_left_panel = MainLeftPanel(model, self)
         mlp = self.main_left_panel
+        self.plots_panel = self.main_left_panel.plots_panel
         self.plots_box = self.main_left_panel.plots_box
 
-        self.main_right_panel = MainRightPanel(model, mlp.plots_box)
+        self.main_right_panel = MainRightPanel(model, self.plots_panel)
         mrp = self.main_right_panel
 
         self.show_radzones = False

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -209,6 +209,7 @@ class FitStatWindow(QtWidgets.QWidget):
         self.fig = Figure()
 
         canvas = FigureCanvas(self.fig)
+        self.canvas = canvas
         toolbar = NavigationToolbar(canvas, parent=None)
 
         toolbar_box = QtWidgets.QHBoxLayout()
@@ -269,6 +270,8 @@ class FitStatWindow(QtWidgets.QWidget):
         self.fig.canvas.flush_events()
 
     def close_window(self, *args):
+        if hasattr(self, "canvas"):
+            self.canvas = None
         self.close()
 
 
@@ -291,6 +294,7 @@ class HistogramWindow(QtWidgets.QWidget):
         self.fig = Figure()
 
         canvas = FigureCanvas(self.fig)
+        self.canvas = canvas
         toolbar = NavigationToolbar(canvas, parent=None)
 
         msid_select = QtWidgets.QComboBox()
@@ -387,6 +391,8 @@ class HistogramWindow(QtWidgets.QWidget):
         self.update_plots()
 
     def close_window(self, *args):
+        if hasattr(self, "canvas"):
+            self.canvas = None
         self.close()
 
     _rz_mask = None
@@ -649,21 +655,40 @@ class HistogramWindow(QtWidgets.QWidget):
         self.fig.canvas.flush_events()
 
 
-class PlotBox(QtWidgets.QVBoxLayout):
-    def __init__(self, plot_name, plots_box):
-        super().__init__()
+class PlotsPanel(QtWidgets.QWidget):
+    """
+    QWidget wrapper for PlotsBox (QVBoxLayout), ensures persistent ownership and correct parent/child relationship.
+    Also exposes main_window for compatibility with code expecting PlotsBox.main_window.
+    """
 
+    def __init__(self, model, main_window):
+        super().__init__()
+        self.main_window = main_window
+        self.model = model
+        self.plots_box = PlotsBox(model, main_window, parent_widget=self)
+        # Keep explicit reference to plot_boxes to prevent GC
+        self._plot_boxes_ref = self.plots_box.plot_boxes
+        layout = QtWidgets.QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(self.plots_box)
+        self.setLayout(layout)
+
+
+class PlotBox(QtWidgets.QWidget):
+    def __init__(self, plot_name, plots_box, parent=None):
+        super().__init__(parent)
+        self.plot_name = plot_name
         comp_name, plot_method = plot_name.split()  # E.g. "tephin fit_resid"
         self.comp = plots_box.model.comp[comp_name]
         self.plot_method = plot_method
         self.comp_name = comp_name
-        self.plot_name = plot_name
+
+        # Layout for this widget
+        vbox = QtWidgets.QVBoxLayout()
+        self.setLayout(vbox)
 
         self.fig = Figure(constrained_layout=True)
         canvas = FigureCanvas(self.fig)
-        # The next two lines make sure that the canvas doesn't
-        # shrink as we add more plots--instead the parent layout
-        # scrolls
         canvas.setMinimumHeight(280)
         canvas.setSizePolicy(
             QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
@@ -681,8 +706,8 @@ class PlotBox(QtWidgets.QVBoxLayout):
         toolbar_box.addStretch(1)
         toolbar_box.addWidget(delete_plot_button)
 
-        self.addWidget(canvas)
-        self.addLayout(toolbar_box)
+        vbox.addWidget(canvas)
+        vbox.addLayout(toolbar_box)
 
         # Add shared x-axes for plots with time on the x-axis
         xaxis = plot_method.split("__")
@@ -824,11 +849,14 @@ class PlotBox(QtWidgets.QVBoxLayout):
 
 
 class PlotsBox(QtWidgets.QVBoxLayout):
-    def __init__(self, model, main_window):
+    def __init__(self, model, main_window, parent_widget=None):
         super().__init__()
         self.main_window = main_window
         self.model = model
-        self.plot_boxes = []
+        self.parent_widget = (
+            parent_widget  # Store the parent widget for proper Qt ownership
+        )
+        self.plot_boxes = []  # Keep strong references to PlotBox objects
         self.plot_names = []
 
         self.set_times()
@@ -867,20 +895,25 @@ class PlotsBox(QtWidgets.QVBoxLayout):
         self.main_window.cbp.add_plot_button.setCurrentIndex(0)
         if plot_name == "Add plot..." or plot_name in self.plot_names:
             return
-        print("Adding plot ", plot_name)
-        plot_box = PlotBox(plot_name, self)
-        self.addLayout(plot_box)
-        plot_box.update(first=True)
+        # Pass parent_widget during PlotBox construction for proper Qt ownership
+        plot_box = PlotBox(plot_name, self, parent=self.parent_widget)
+        # Keep strong references BEFORE any other operations
         self.plot_boxes.append(plot_box)
         self.plot_names.append(plot_name)
+        # Now add to layout - layout takes ownership but we keep Python ref
+        self.addWidget(plot_box)
+        # Defer update to allow Qt to fully establish ownership
+        # This prevents premature garbage collection of the PlotBox
+        QtCore.QTimer.singleShot(0, lambda: plot_box.update(first=True))
 
     def delete_plot_box(self, plot_name):
         for i, pb in enumerate(list(self.plot_boxes)):
             if pb.plot_name == plot_name:
                 self.plot_boxes.pop(i)
                 self.plot_names.pop(i)
-                self.removeItem(pb)
-                clear_layout(pb)
+                self.removeWidget(pb)
+                pb.setParent(None)
+                pb.deleteLater()
                 break
         self.update()
 

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -657,8 +657,9 @@ class HistogramWindow(QtWidgets.QWidget):
 
 class PlotsPanel(QtWidgets.QWidget):
     """
-    QWidget wrapper for PlotsBox (QVBoxLayout), ensures persistent ownership and correct parent/child relationship.
-    Also exposes main_window for compatibility with code expecting PlotsBox.main_window.
+    QWidget wrapper for PlotsBox (QVBoxLayout), ensures persistent ownership and correct
+    parent/child relationship. Also exposes main_window for compatibility with code
+    expecting PlotsBox.main_window.
     """
 
     def __init__(self, model, main_window):

--- a/xija/gui_fit/plots.py
+++ b/xija/gui_fit/plots.py
@@ -690,6 +690,9 @@ class PlotBox(QtWidgets.QWidget):
 
         self.fig = Figure(constrained_layout=True)
         canvas = FigureCanvas(self.fig)
+        # The next two lines make sure that the canvas doesn't
+        # shrink as we add more plots--instead the parent layout
+        # scrolls
         canvas.setMinimumHeight(280)
         canvas.setSizePolicy(
             QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
@@ -896,6 +899,7 @@ class PlotsBox(QtWidgets.QVBoxLayout):
         self.main_window.cbp.add_plot_button.setCurrentIndex(0)
         if plot_name == "Add plot..." or plot_name in self.plot_names:
             return
+        print("Adding plot ", plot_name)
         # Pass parent_widget during PlotBox construction for proper Qt ownership
         plot_box = PlotBox(plot_name, self, parent=self.parent_widget)
         # Keep strong references BEFORE any other operations


### PR DESCRIPTION
## Description

More fixes for xija_gui_fit to stop RuntimeError FigureCanvasQTAgg has been deleted.

This was required for me for xija_gui_fit to run at all when installed in ska3/hope on OSX - and seems to improve reliability for ska3/latest installs.

Without these fixes I was just getting this when I tried to run xija_gui_fit from the installed environment.
```
Adding plot  aacccdpt data__time
Adding plot  aacccdpt resid__time
Traceback (most recent call last):
  File "/Users/jean/miniforge3/envs/ska3-flight-2026.0rc4/lib/python3.13/site-packages/matplotlib/backend_bases.py", line 2926, in _wait_cursor_for_draw_cm
    yield
  File "/Users/jean/miniforge3/envs/ska3-flight-2026.0rc4/lib/python3.13/site-packages/matplotlib/backends/backend_agg.py", line 385, in draw
    super().draw()
    ~~~~~~~~~~~~^^
  File "/Users/jean/miniforge3/envs/ska3-flight-2026.0rc4/lib/python3.13/site-packages/matplotlib/backends/backend_qt.py", line 492, in draw
    self.update()
    ~~~~~~~~~~~^^
RuntimeError: wrapped C/C++ object of type FigureCanvasQTAgg has been deleted

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jean/miniforge3/envs/ska3-flight-2026.0rc4/lib/python3.13/site-packages/matplotlib/backends/backend_qt.py", line 523, in _draw_idle
    self.draw()
    ~~~~~~~~~^^
  File "/Users/jean/miniforge3/envs/ska3-flight-2026.0rc4/lib/python3.13/site-packages/matplotlib/backends/backend_agg.py", line 380, in draw
    with (self.toolbar._wait_cursor_for_draw_cm() if self.toolbar
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          else nullcontext()):
          ^^^^^^^^^^^^^^^^^^
  File "/Users/jean/miniforge3/envs/ska3-flight-2026.0rc4/lib/python3.13/contextlib.py", line 162, in __exit__
    self.gen.throw(value)
    ~~~~~~~~~~~~~~^^^^^^^
  File "/Users/jean/miniforge3/envs/ska3-flight-2026.0rc4/lib/python3.13/site-packages/matplotlib/backend_bases.py", line 2928, in _wait_cursor_for_draw_cm
    self.canvas.set_cursor(self._last_cursor)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/jean/miniforge3/envs/ska3-flight-2026.0rc4/lib/python3.13/site-packages/matplotlib/backends/backend_qt.py", line 284, in set_cursor
    self.setCursor(_api.check_getitem(cursord, cursor=cursor))
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: wrapped C/C++ object of type FigureCanvasQTAgg has been deleted
```
Strangely, it worked *fine* running straight from the repo with `python -m xija.gui_fit.app` but didn't work after being installed.  So that was just weird.  But with these Qt changes the code changed to reliably running from either the repo or "as installed" with xija_gui_fit for me on OSX with a recent hope candidate.

This issue seems to be a recurrence of https://github.com/sot/xija/issues/126 which we believed fixed with https://github.com/sot/xija/pull/127 .

I don't entirely understand the timing and Qt.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #126 again

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac with a latest ska3
```
(latest) flame:xija jean$ pytest
=========================================================== test session starts ============================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 45 items                                                                                                                         

xija/tests/test_get_model_spec.py .......                                                                                            [ 15%]
xija/tests/test_models.py ......................................                                                                     [100%]

============================================================= warnings summary =============================================================
xija/xija/tests/test_models.py::test_dpa_real[True]
  /Users/jean/miniforge3/envs/latest/lib/python3.12/site-packages/setuptools_scm/git.py:312: UserWarning: git archive did not support describe output
    warnings.warn("git archive did not support describe output")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================== 45 passed, 1 warning in 36.15
```

Independent check of unit tests by Javier
- [x] OSX + ska3-hope
```
(ska3-flight-2026.0rc9) ~/miniforge3/envs/ska3-flight-2026.0rc9/lib/python3.13/site-packages $ python -c "import xija; print(xija.__version__)"
4.35.1.dev5+g791f0eef8
(ska3-flight-2026.0rc9) ~/miniforge3/envs/ska3-flight-2026.0rc9/lib/python3.13/site-packages $ pytest xija/tests/test_get_model_spec.py::test_check_github_version
============================================================= test session starts =============================================================
platform darwin -- Python 3.13.10, pytest-9.0.1, pluggy-1.6.0
rootdir: /Users/javierg/miniforge3/envs/ska3-flight-2026.0rc9/lib/python3.13/site-packages
plugins: anyio-4.12.0, timeout-2.4.0
collected 1 item                                                                                                                              

xija/tests/test_get_model_spec.py .                                                                                                     [100%]

============================================================== 1 passed in 1.10s ==============================================================

```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

For functional testing, I've made test conda packages and tested this on:

- [x] OSX with ska3 "latest"
- [x] OSX with ska3 "hope"
- [x] kady Linux with ska3 "hope" at rc8
- [x] kady Linux ska3 "latest"  

My test was just to run "xija_gui_fit aca", add at least one plot, and run a fit.  On each platform, I got a crash without this PR before xija_gui_fit really started and it worked OK as far as I could tell with the PR.  On kady linux I note that my matplotlibrc is set to use TkAgg, so if I wanted to run xija_gui_fit without "            newbackend, required_framework, current_framework))
ImportError: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework, as 'qt' is currently running" I just specified the qt backend by env var with "env MPLBACKEND=qt5agg xija_gui_fit aca".

John Zuhone also noted additional functional testing in the comments.
